### PR TITLE
Dev: bugfixes and enhancements (0.34)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,7 +2,13 @@ name: Tests
 
 on:
   push:
+    paths:
+      - '**.py'
+      - '.github/workflows/tests.yml'
   pull_request:
+    paths:
+      - '**.py'
+      - '.github/workflows/tests.yml'
 
 jobs:
   test:

--- a/README.md
+++ b/README.md
@@ -3,7 +3,8 @@
 
 ## Overview
 
-WhatsApp Media Archiver organises your WhatsApp media into a structured folder hierarchy using metadata from the WhatsApp database (`msgstore.db`). Instead of an unstructured dump, you get a browsable archive sorted by contact or group, year, and direction (Sent/Received), with original message timestamps preserved.
+WhatsApp Media Archiver organises your WhatsApp media into a structured folder hierarchy using metadata from the WhatsApp database. 
+Instead of an unstructured dump, you get a browsable archive sorted by contact or group, year, and direction (Sent/Received), with original message timestamps preserved.
 
 > ⚠️ **This tool is designed to run on a backup copy of your WhatsApp data — never on live device files.** For safeguard reasons, this script will always make a copy of your data.
 
@@ -21,8 +22,10 @@ WhatsApp Media Archiver organises your WhatsApp media into a structured folder h
 - Duplicate media detection across runs — CSV report of files with identical content at multiple archive paths
 - Missing media CSV report for manual recovery of old or deleted files
 - Dry run mode for safe previewing before a full run
-- iOS support — reads directly from an iPhone backup (`--ios_backup`); no third-party extraction tool required
-- Encrypted backup support (`msgstore.db.crypt15`) via `wa-crypt-tools`
+- Windows, Linux and MacOS are supported to run the script.
+- WhatsApp platform: Android and iOS are both supported. No root or jailbreak are required.
+    - Android: requires a manual copy of your `/Whatsapp/Media/` folder
+    - iOS: reads directly from an iPhone backup, encrypted backups are supported via `wa-crypt-tools`
 - Restore mode — reconstructs the original `WhatsApp/Media/` folder structure from the archive (Android only)
 
 ### Supported Media Types
@@ -122,7 +125,7 @@ The script is **safe to re-run** on an existing archive:
 - Stickers are not archived in this version.
 - **Year folders reflect the local time of the machine running the script**, not UTC. A message sent just after midnight on 1 January will be filed under the new year only if your machine's clock agrees. This is intentional — the archive reflects your local experience of when media was shared.
 - **iOS restore mode is not supported.** Restore mode reconstructs the Android `Media/` folder layout, which has no equivalent on iOS. Running `--mode restore` on an iOS archive exits with a clear error.
-- **iOS number change tracking is best-effort.** Contacts present in the device address book are consolidated automatically. Contacts not saved to the address book (`ZCONTACTABID = NULL`) appear as separate folders.
+- **iOS number change tracking is best-effort.** Contacts present in the device address book are consolidated automatically. Contacts not saved to the address book appear as separate folders.
 
 ---
 

--- a/docs/prerequisites.md
+++ b/docs/prerequisites.md
@@ -7,15 +7,21 @@ Ensure Python 3.10+ is installed.
 
 This script relies on some packages for Android and iOS.
 
-Install the relevant package before your first run.
+Install the relevant package before your first run. If you miss any of these, the script will notify you.
 
-For Android encrypted backup decryption, the script uses `wa-crypt-tools`. You are going to use it if you don't have a rooted device.
+
+
+**Android encrypted backup decryption** 
+
+The script uses `wa-crypt-tools`. You are going to use it if you don't have a rooted device.
 
 ```bash
 pip install wa-crypt-tools
 ```
 
-For iOS encrypted backup decryption, the script uses `iphone-backup-decrypt`. You are going to use it if you create password protected iOS backups.
+**iOS encrypted backup decryption** 
+
+The script uses `iphone-backup-decrypt`. You are going to use it if you create password protected iOS backups.
 
 ```bash
 pip install iphone-backup-decrypt
@@ -23,7 +29,10 @@ pip install iphone-backup-decrypt
 
 > 💡 Windows Users: your Python environment may not have pip in the PATH. If `pip install` doesn't work for you, `use py -m pip install`.
 
-> 💡 **Windows users — `--timezone`:** if you plan to use the `--timezone` argument, Windows requires one additional package. macOS and Linux ship the IANA timezone database as part of the OS; Windows does not.
+
+**Timezone feature for Windows**
+
+If you plan to use the `--timezone` argument, Windows requires one additional package. macOS and Linux ship the IANA timezone database as part of the OS; Windows does not.
 > ```
 > pip install tzdata
 > ```
@@ -59,7 +68,7 @@ When asked, create the end-to-end ecrypted backup.
 ### Your WhatsApp Media Folder
 
 Before you run the script, you need your WhatsApp (Media) folder on disk - actually, the folder called `WhatsApp` that **contains** the `Media` subfolder. 
-You need to copy this folder from your phone: you can use [Syncthing](https://syncthing.net/) to ease the process.
+You need to copy this folder from your phone: you can use [Syncthing](https://syncthing.net/) to smooth the process.
 
 ```
 /path/to/WhatsApp/

--- a/docs/prerequisites.md
+++ b/docs/prerequisites.md
@@ -23,6 +23,12 @@ pip install iphone-backup-decrypt
 
 > 💡 Windows Users: your Python environment may not have pip in the PATH. If `pip install` doesn't work for you, `use py -m pip install`.
 
+> 💡 **Windows users — `--timezone`:** if you plan to use the `--timezone` argument, Windows requires one additional package. macOS and Linux ship the IANA timezone database as part of the OS; Windows does not.
+> ```
+> pip install tzdata
+> ```
+> This is only needed when `--timezone` is used. Normal runs without `--timezone` work on Windows without it.
+
 
 ---
 

--- a/docs/running-the-script.md
+++ b/docs/running-the-script.md
@@ -38,7 +38,7 @@ usage: wa_media_archiver.py [-h]
 | `--dry-run` | No | Simulate the run without copying any files |
 | `--limit N` | No | Cap rows returned per chat type (N/2 from groups, N/2 from 1-to-1). Total rows ≤ N. Useful for test runs |
 | `--since DATE` | No | Only include messages on or after this date (`YYYY-MM-DD`). Combines freely with `--limit` |
-| `--timezone TZ` | No | IANA timezone name for year folder assignment and report timestamps (e.g. `Europe/Rome`, `America/New_York`, `UTC`). Ensures files land in the correct `<YYYY>/` subfolder regardless of where or when the script is run. Also applied to `--since` date interpretation. Defaults to machine local time. **Windows users: requires `pip install tzdata`** |
+| `--timezone TZ` | No | [IANA timezone name](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones#List) for year folder assignment and report timestamps (e.g. `Europe/Rome`, `America/New_York`, `UTC`). Ensures files land in the correct `<YYYY>/` subfolder regardless of where or when the script is run. Also applied to `--since` date interpretation. Defaults to machine local time. **Windows users: requires `pip install tzdata`** |
 
 ---
 
@@ -175,7 +175,7 @@ python3 wa_media_archiver.py \
 
 Restore mode reconstructs the flat `WhatsApp/Media/` folder structure directly inside the archive folder, without needing the original device or database. This is useful when re-importing media into tools that expect the original WhatsApp layout.
 
-> ⚠️ **Android archives only.** iOS media is stored at `Message/Media/...` paths that have no equivalent reconstruction target outside the iPhone backup format. Running restore mode on an iOS archive exits with a clear error.
+> ⚠️ **Android archives only.** iOS media is stored at `Message/Media/...` paths that have no equivalent reconstruction target outside the iPhone backup format. Running restore mode on an iOS archive is disallowed.
 
 The reconstructed tree is written to `<output>/Media/`, alongside the existing `Contacts/` and `Groups/` folders. No files are overwritten — identical files already in place are skipped silently.
 

--- a/docs/running-the-script.md
+++ b/docs/running-the-script.md
@@ -19,6 +19,7 @@ usage: wa_media_archiver.py [-h]
                       [--dry-run]
                       [--limit N]
                       [--since DATE]
+                      [--timezone TZ]
 ```
 
 | Argument | Required | Description |
@@ -37,6 +38,7 @@ usage: wa_media_archiver.py [-h]
 | `--dry-run` | No | Simulate the run without copying any files |
 | `--limit N` | No | Cap rows returned per chat type (N/2 from groups, N/2 from 1-to-1). Total rows ≤ N. Useful for test runs |
 | `--since DATE` | No | Only include messages on or after this date (`YYYY-MM-DD`). Combines freely with `--limit` |
+| `--timezone TZ` | No | IANA timezone name for year folder assignment and report timestamps (e.g. `Europe/Rome`, `America/New_York`, `UTC`). Ensures files land in the correct `<YYYY>/` subfolder regardless of where or when the script is run. Also applied to `--since` date interpretation. Defaults to machine local time. **Windows users: requires `pip install tzdata`** |
 
 ---
 

--- a/tests/test_wa_media_archiver.py
+++ b/tests/test_wa_media_archiver.py
@@ -148,6 +148,36 @@ class TestGetYear:
         year = wa.get_year(ts_ms)
         assert year == "2024"
 
+    def test_utc_timezone(self):
+        pytest.importorskip('zoneinfo', reason="zoneinfo unavailable")
+        from zoneinfo import ZoneInfo
+        try:
+            tz = ZoneInfo('UTC')
+        except Exception:
+            pytest.skip("tzdata not installed")
+        # 2024-12-31 23:30:00 UTC → still 2024 in UTC
+        ts_ms = 1735688200000  # 2024-12-31 23:36:40 UTC
+        assert wa.get_year(ts_ms, tz=tz) == "2024"
+
+    def test_timezone_crosses_year_boundary(self):
+        from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+        try:
+            rome = ZoneInfo('Europe/Rome')
+            utc  = ZoneInfo('UTC')
+        except ZoneInfoNotFoundError:
+            pytest.skip("tzdata not installed (required on Windows)")
+        # 2024-12-31 23:30:00 UTC = 2025-01-01 00:30:00 in UTC+1 (Europe/Rome in winter)
+        ts_ms = 1735687800000  # 2024-12-31 23:30:00 UTC exactly
+        assert wa.get_year(ts_ms, tz=rome) == "2025"
+        assert wa.get_year(ts_ms, tz=utc)  == "2024"
+
+    def test_no_tz_returns_string(self):
+        # Without tz, returns a 4-digit year string (value depends on local time, just check format)
+        ts_ms = 1705276800000
+        year = wa.get_year(ts_ms)
+        assert len(year) == 4
+        assert year.isdigit()
+
 
 class TestAppendSenderToFilename:
     def test_normal_case(self):

--- a/tests/test_wa_media_archiver.py
+++ b/tests/test_wa_media_archiver.py
@@ -1869,3 +1869,56 @@ class TestPullContacts:
                    side_effect=subprocess.CalledProcessError(1, 'adb', stderr=b"fail")):
             with pytest.raises(subprocess.CalledProcessError):
                 adb.pull_contacts(str(tmp_path), logger=logger)
+
+
+# ---------------------------------------------------------------------------
+# TestCheckDependencies
+# ---------------------------------------------------------------------------
+
+class TestCheckDependencies:
+    def _args(self, **kwargs):
+        """Return a minimal namespace; only set the fields under test."""
+        defaults = dict(mode=None, e2e_key=None, ios_password=None)
+        defaults.update(kwargs)
+        import argparse
+        return argparse.Namespace(**defaults)
+
+    def test_no_issues_passes_silently(self, logger):
+        args = self._args()
+        wa.check_dependencies(args, logger)  # must not raise
+
+    def test_adb_missing_raises(self, logger):
+        args = self._args(mode='adb')
+        with patch("wa_media_archiver.shutil.which", return_value=None):
+            with pytest.raises(SystemExit):
+                wa.check_dependencies(args, logger)
+
+    def test_adb_present_passes(self, logger):
+        args = self._args(mode='adb')
+        with patch("wa_media_archiver.shutil.which", return_value="/usr/bin/adb"):
+            wa.check_dependencies(args, logger)  # must not raise
+
+    def test_wa_crypt_tools_missing_raises(self, logger):
+        args = self._args(e2e_key='key.bin')
+        with patch("importlib.util.find_spec", return_value=None):
+            with pytest.raises(SystemExit):
+                wa.check_dependencies(args, logger)
+
+    def test_iphone_backup_decrypt_missing_raises(self, logger):
+        args = self._args(ios_password='secret')
+        with patch("importlib.util.find_spec", return_value=None):
+            with pytest.raises(SystemExit):
+                wa.check_dependencies(args, logger)
+
+    def test_multiple_missing_reported_together(self, logger, caplog):
+        args = self._args(mode='adb', e2e_key='key.bin')
+        # Capture what logger.error receives by inspecting the call
+        errors = []
+        logger.error = lambda msg, *a, **kw: errors.append(msg)
+        with patch("wa_media_archiver.shutil.which", return_value=None), \
+             patch("importlib.util.find_spec", return_value=None), \
+             pytest.raises(SystemExit):
+            wa.check_dependencies(args, logger)
+        assert len(errors) == 1, "Expected a single combined error message"
+        assert "adb" in errors[0]
+        assert "wa-crypt-tools" in errors[0]

--- a/wa_media_archiver.py
+++ b/wa_media_archiver.py
@@ -96,14 +96,14 @@ def set_file_times(path: str, timestamp_ms: int):
     os.utime(path, (ts, ts))
 
 
-def get_year(timestamp_ms: int) -> str:
+def get_year(timestamp_ms: int, tz=None) -> str:
     """Extract year string from a WhatsApp timestamp (ms)."""
-    return datetime.fromtimestamp(timestamp_ms / 1000).strftime('%Y')
+    return datetime.fromtimestamp(timestamp_ms / 1000, tz=tz).strftime('%Y')
 
 
-def human_datetime(timestamp_ms: int) -> str:
+def human_datetime(timestamp_ms: int, tz=None) -> str:
     """Convert WhatsApp timestamp (ms) to a human-readable string."""
-    return datetime.fromtimestamp(timestamp_ms / 1000).strftime('%Y-%m-%d %H:%M:%S')
+    return datetime.fromtimestamp(timestamp_ms / 1000, tz=tz).strftime('%Y-%m-%d %H:%M:%S')
 
 
 def append_sender_to_filename(filename: str, sender: str) -> str:
@@ -537,7 +537,7 @@ def sync_folder_names(contacts: dict, number_map: dict, output_root: str,
 
 def _build_missing_row(msg_id, timestamp, file_path, mime_type,
                        chat_subject, sender, key_from_me, message_url, media_name,
-                       contacts, number_map, filename='') -> dict:
+                       contacts, number_map, filename='', tz=None) -> dict:
     """Build a missing-media report row for either a null file_path or a missing source file."""
     canonical = number_map.get(sender, sender) if sender else None
     if chat_subject is not None:
@@ -550,7 +550,7 @@ def _build_missing_row(msg_id, timestamp, file_path, mime_type,
             else (contacts.get(canonical, canonical) if canonical else 'Unknown')
     return {
         'message_id':        msg_id,
-        'timestamp_human':   human_datetime(timestamp) if timestamp else '',
+        'timestamp_human':   human_datetime(timestamp, tz) if timestamp else '',
         'original_filename': filename,
         'mime_type':         mime_type or '',
         'sender':            sender_display,
@@ -637,7 +637,7 @@ def _copy_or_skip(src, dest_path, dest_dir, file_path, timestamp,
 
 
 def process_rows(rows, total: int, contacts, number_map, folder_index, group_index,
-                 media_resolver, output_root, logger, dry_run, conn=None):
+                 media_resolver, output_root, logger, dry_run, conn=None, tz=None):
     stats = {'copied': 0, 'skipped': 0, 'missing': 0, 'warnings': 0}
     updated_index = dict(folder_index)
     updated_group_index = dict(group_index)
@@ -660,7 +660,7 @@ def process_rows(rows, total: int, contacts, number_map, folder_index, group_ind
             missing_rows.append(_build_missing_row(
                 msg_id, timestamp, None, mime_type, chat_subject, sender,
                 key_from_me, message_url, media_name, contacts, number_map,
-                filename=filename,
+                filename=filename, tz=tz,
             ))
             stats['missing'] += 1
             continue
@@ -672,7 +672,7 @@ def process_rows(rows, total: int, contacts, number_map, folder_index, group_ind
             missing_rows.append(_build_missing_row(
                 msg_id, timestamp, file_path, mime_type, chat_subject, sender,
                 key_from_me, message_url, media_name, contacts, number_map,
-                filename=filename,
+                filename=filename, tz=tz,
             ))
             stats['missing'] += 1
             continue
@@ -682,12 +682,12 @@ def process_rows(rows, total: int, contacts, number_map, folder_index, group_ind
             missing_rows.append(_build_missing_row(
                 msg_id, timestamp, file_path, mime_type, chat_subject, sender,
                 key_from_me, message_url, media_name, contacts, number_map,
-                filename=filename,
+                filename=filename, tz=tz,
             ))
             stats['missing'] += 1
             continue
 
-        year = get_year(timestamp)
+        year = get_year(timestamp, tz)
 
         if is_group:
             dest_dir, dest_filename = _route_group(
@@ -942,6 +942,13 @@ def parse_args() -> argparse.Namespace:
                         metavar='DATE',
                         help='Only include messages on or after this date '
                              '(format: YYYY-MM-DD). Combines with --limit.')
+    parser.add_argument('--timezone',
+                        default=None,
+                        metavar='TZ',
+                        help='IANA timezone for year folders and report timestamps '
+                             '(e.g. Europe/Rome, America/New_York, UTC). '
+                             'Default: machine local time. '
+                             'Windows users: requires pip install tzdata.')
     args = parser.parse_args()
 
     if args.ios_backup and args.wa_root:
@@ -1137,11 +1144,29 @@ def run_forward_mode(args: argparse.Namespace, logger: logging.Logger):
         platform = detect_db_platform(args.msgstore)
         logger.info(f"Detected platform: {platform}")
 
+    # --- Resolve --timezone ---
+    from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+    tz = None
+    if args.timezone:
+        try:
+            tz = ZoneInfo(args.timezone)
+        except ZoneInfoNotFoundError:
+            msg = f"Unknown timezone: '{args.timezone}'."
+            if sys.platform == 'win32':
+                msg += "\n  On Windows, the IANA timezone database must be installed: pip install tzdata"
+            msg += "\n  Use an IANA name, e.g. Europe/Rome, America/New_York, UTC."
+            logger.error(msg)
+            raise SystemExit(1)
+        logger.info(f"Timezone: {args.timezone}")
+
     # --- Parse --since and --limit ---
     since_ms = None
     if args.since:
         try:
-            since_ms = int(datetime.strptime(args.since, '%Y-%m-%d').timestamp() * 1000)
+            since_dt = datetime.strptime(args.since, '%Y-%m-%d')
+            if tz:
+                since_dt = since_dt.replace(tzinfo=tz)
+            since_ms = int(since_dt.timestamp() * 1000)
         except ValueError:
             logger.error(f"Invalid --since date '{args.since}'. Expected format: YYYY-MM-DD")
             raise SystemExit(1)
@@ -1218,6 +1243,7 @@ def run_forward_mode(args: argparse.Namespace, logger: logging.Logger):
                 cursor, total_rows, contacts, number_map, folder_index, group_index,
                 media_resolver, args.output, logger, args.dry_run,
                 conn=archive_conn if not args.dry_run else None,
+                tz=tz,
             )
 
             if not args.dry_run:

--- a/wa_media_archiver.py
+++ b/wa_media_archiver.py
@@ -1086,8 +1086,44 @@ def _prepare_input(args: argparse.Namespace, logger: logging.Logger):
     return platform, media_resolver, ios_contacts_path, contacts
 
 
+def check_dependencies(args: argparse.Namespace, logger: logging.Logger):
+    """Check all required external dependencies upfront and report everything missing at once."""
+    import importlib.util
+    issues = []
+
+    if getattr(args, 'mode', None) == 'adb' and shutil.which('adb') is None:
+        issues.append(
+            "adb not found on PATH\n"
+            "      macOS/Linux: brew install android-platform-tools\n"
+            "      Windows:     download platform-tools from developer.android.com/tools/releases/platform-tools"
+        )
+    if getattr(args, 'e2e_key', None) and importlib.util.find_spec('wa_crypt_tools') is None:
+        issues.append(
+            "wa-crypt-tools is not installed\n"
+            "      Run: pip install wa-crypt-tools"
+        )
+    if getattr(args, 'ios_password', None) and importlib.util.find_spec('iphone_backup_decrypt') is None:
+        issues.append(
+            "iphone-backup-decrypt is not installed\n"
+            "      Run: pip install iphone-backup-decrypt"
+        )
+    if getattr(args, 'timezone', None) and sys.platform == 'win32' \
+            and importlib.util.find_spec('tzdata') is None:
+        issues.append(
+            "tzdata is not installed (required for --timezone on Windows)\n"
+            "      Run: pip install tzdata"
+        )
+
+    if issues:
+        msg = "Missing dependencies for the requested operation:\n\n"
+        msg += "\n\n".join(f"  • {i}" for i in issues)
+        logger.error(msg)
+        raise SystemExit(1)
+
+
 def run_forward_mode(args: argparse.Namespace, logger: logging.Logger):
     """Execute a full forward archival run."""
+    check_dependencies(args, logger)
     platform, media_resolver, ios_contacts_path, contacts = _prepare_input(args, logger)
 
     # --- Validate DB exists ---

--- a/wa_media_archiver.py
+++ b/wa_media_archiver.py
@@ -1,3 +1,13 @@
+import sys
+if sys.version_info < (3, 10):
+    print(
+        f"ERROR: Python 3.10 or higher is required "
+        f"(you are running {sys.version.split()[0]}).\n"
+        "  Download the latest Python from https://www.python.org/downloads/",
+        file=sys.stderr,
+    )
+    sys.exit(1)
+
 import atexit
 import argparse
 import contextlib

--- a/wa_media_archiver.py
+++ b/wa_media_archiver.py
@@ -1058,7 +1058,20 @@ def _prepare_input(args: argparse.Namespace, logger: logging.Logger):
             db = DatabaseFactory.from_file(msg)
             raw = msg.read()  # payload only — from_file already consumed the header
         key = KeyFactory.new(args.e2e_key)
-        decrypted = db.decrypt(key, raw)
+        if key is None:
+            logger.error(
+                f"Could not load decryption key from: {args.e2e_key}\n"
+                "  Make sure --e2e_key points to a valid WhatsApp key file."
+            )
+            raise SystemExit(1)
+        try:
+            decrypted = db.decrypt(key, raw)
+        except Exception as e:
+            logger.error(
+                f"Decryption failed: {e}\n"
+                "  The key file may not match this backup."
+            )
+            raise SystemExit(1)
         try:
             output_file = zlib.decompress(decrypted)
         except zlib.error:

--- a/wa_media_archiver.py
+++ b/wa_media_archiver.py
@@ -619,18 +619,21 @@ def _copy_or_skip(src, dest_path, dest_dir, file_path, timestamp,
 
     os.makedirs(dest_dir, exist_ok=True)
     try:
-        shutil.copy2(src, resolved)
-        set_file_times(resolved, timestamp)
-        if src_hash is None:
-            src_hash = file_md5(resolved)
-        logger.debug(f"COPIED: {src} -> {resolved}")
-        if cursor is not None:
-            rel = os.path.relpath(resolved, output_root).replace(os.sep, '/')
-            record_file_archived(cursor, file_path, src_hash, rel)
-        return 1, 0, 0
+        shutil.copy(src, resolved)
     except Exception as e:
         logger.error(f"ERROR copying {src} -> {resolved}: {e}")
         return 0, 0, 1
+    try:
+        set_file_times(resolved, timestamp)
+    except OSError as e:
+        logger.debug(f"Could not set timestamps on {resolved}: {e}")
+    if src_hash is None:
+        src_hash = file_md5(resolved)
+    logger.debug(f"COPIED: {src} -> {resolved}")
+    if cursor is not None:
+        rel = os.path.relpath(resolved, output_root).replace(os.sep, '/')
+        record_file_archived(cursor, file_path, src_hash, rel)
+    return 1, 0, 0
 
 
 def process_rows(rows, total: int, contacts, number_map, folder_index, group_index,


### PR DESCRIPTION
**Added**:

- **Python version check**: the script now exits immediately with a clear message if run under Python < 3.10, rather than crashing with a cryptic `TypeError` on the `int | None` type annotation syntax.
- **Upfront dependency check**: `check_dependencies()` now runs immediately after argument parsing, before any file I/O or ADB calls.
- **`--timezone` argument**: IANA timezone name (e.g. `Europe/Rome`, `America/New_York`, `UTC`) for consistent year folder assignment and report timestamps, regardless of the machine's local clock. Affects which `<YYYY>/` subfolder files land in and the `timestamp_human` column in `missing_media_report.csv`. Also applied to `--since` date interpretation. Uses `zoneinfo` (stdlib, Python 3.10+); on Windows requires `pip install tzdata`. Defaults to machine local time.

**Fixed**:
- **File transfers from SMB/network shares incorrectly counted as errors on macOS and Linux**: `shutil.copy2` calls `copystat()` which reads extended attributes and ownership from the source. On SMB mounts this raises `[Errno 1] Operation not permitted` even with full read access, causing the copy to be reported as failed and the WhatsApp timestamp to not be applied.
- **Wrong or invalid `--e2e_key` crashes without a clear error message
- docs: several enhancements