### PR TITLE
Dev: v0.35

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,674 @@
+                    GNU GENERAL PUBLIC LICENSE
+                       Version 3, 29 June 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The GNU General Public License is a free, copyleft license for
+software and other kinds of works.
+
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+the GNU General Public License is intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.  We, the Free Software Foundation, use the
+GNU General Public License for most of our software; it applies also to
+any other work released this way by its authors.  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
+
+  To protect your rights, we need to prevent others from denying you
+these rights or asking you to surrender the rights.  Therefore, you have
+certain responsibilities if you distribute copies of the software, or if
+you modify it: responsibilities to respect the freedom of others.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must pass on to the recipients the same
+freedoms that you received.  You must make sure that they, too, receive
+or can get the source code.  And you must show them these terms so they
+know their rights.
+
+  Developers that use the GNU GPL protect your rights with two steps:
+(1) assert copyright on the software, and (2) offer you this License
+giving you legal permission to copy, distribute and/or modify it.
+
+  For the developers' and authors' protection, the GPL clearly explains
+that there is no warranty for this free software.  For both users' and
+authors' sake, the GPL requires that modified versions be marked as
+changed, so that their problems will not be attributed erroneously to
+authors of previous versions.
+
+  Some devices are designed to deny users access to install or run
+modified versions of the software inside them, although the manufacturer
+can do so.  This is fundamentally incompatible with the aim of
+protecting users' freedom to change the software.  The systematic
+pattern of such abuse occurs in the area of products for individuals to
+use, which is precisely where it is most unacceptable.  Therefore, we
+have designed this version of the GPL to prohibit the practice for those
+products.  If such problems arise substantially in other domains, we
+stand ready to extend this provision to those domains in future versions
+of the GPL, as needed to protect the freedom of users.
+
+  Finally, every program is threatened constantly by software patents.
+States should not allow patents to restrict development and use of
+software on general-purpose computers, but in those that do, we wish to
+avoid the special danger that patents applied to a free program could
+make it effectively proprietary.  To prevent this, the GPL assures that
+patents cannot be used to render the program non-free.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                       TERMS AND CONDITIONS
+
+  0. Definitions.
+
+  "This License" refers to version 3 of the GNU General Public License.
+
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
+
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
+
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
+
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
+
+  To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
+
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
+
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
+
+  1. Source Code.
+
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
+
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
+
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
+
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
+
+  The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
+
+  The Corresponding Source for a work in source code form is that
+same work.
+
+  2. Basic Permissions.
+
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
+
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
+
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
+
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
+
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
+
+  4. Conveying Verbatim Copies.
+
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
+
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+  5. Conveying Modified Source Versions.
+
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
+
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+  6. Conveying Non-Source Forms.
+
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
+
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
+
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
+
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
+
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+  7. Additional Terms.
+
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+  However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+  An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+  11. Patents.
+
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
+
+  A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
+
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+  A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+  12. No Surrender of Others' Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
+
+  13. Use with the GNU Affero General Public License.
+
+  Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU Affero General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the special requirements of the GNU Affero General Public License,
+section 13, concerning interaction through a network will apply to the
+combination as such.
+
+  14. Revised Versions of this License.
+
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU General Public License, you may choose any version ever published
+by the Free Software Foundation.
+
+  If the Program specifies that a proxy can decide which future
+versions of the GNU General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
+
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
+
+  15. Disclaimer of Warranty.
+
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. Limitation of Liability.
+
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+state the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+  If the program does terminal interaction, make it output a short
+notice like this when it starts in an interactive mode:
+
+    <program>  Copyright (C) <year>  <name of author>
+    This program comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, your program's commands
+might be different; for a GUI interface, you would use an "about box".
+
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU GPL, see
+<https://www.gnu.org/licenses/>.
+
+  The GNU General Public License does not permit incorporating your program
+into proprietary programs.  If your program is a subroutine library, you
+may consider it more useful to permit linking proprietary applications with
+the library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.  But first, please read
+<https://www.gnu.org/licenses/why-not-lgpl.html>.

--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ The script is **safe to re-run** on an existing archive:
 - Files with the same name but different content will be **renamed with a numeric suffix** and logged as a warning
 - New media not yet in the archive will be **copied normally**
 - If a contact has been **renamed** since the last run, their folder on disk will be **automatically renamed** to match, keeping the archive consolidated
+- Recommended: use the script config file to keep settings for easier re-runs.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ After a successful run, the archive will be organized as follows:
 
 ### Platform
 
-The script runs on **Linux, macOS, and Windows** (Python 3.10+).
+The script runs on **Linux, macOS, and Windows** (Python 3.11 required).
 
 > ⚠️ If you have WhatsApp on Android, **run the script on the same machine where the media files are physically stored.** Processing files over a network share (NFS, SMB, etc.) will be significantly slower.
 
@@ -81,7 +81,7 @@ The script runs on **Linux, macOS, and Windows** (Python 3.10+).
 
 ## Prerequisites
 
-- **Python 3.10+** required
+- **Python 3.11** or later is required
 - **Android**: End-to-end encrypted backup must be **enabled** in WhatsApp before pulling the database. Root is not required
 - **iOS/iPadOS**: End-to-end encrypted backup must be **disabled**
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
 
+<p align="center">
+  <img src="icon.svg" alt="WhatsApp Media Archiver" width="120"/>
+</p>
+
 # WhatsApp Media Archiver
 
 ## Overview

--- a/README.md
+++ b/README.md
@@ -1,10 +1,8 @@
+# WhatsApp Media Archiver
 
 <p align="center">
   <img src="icon.svg" alt="WhatsApp Media Archiver" width="120"/>
 </p>
-
-# WhatsApp Media Archiver
-
 ## Overview
 
 WhatsApp Media Archiver organises your WhatsApp media into a structured folder hierarchy using metadata from the WhatsApp database. 

--- a/archive_db.py
+++ b/archive_db.py
@@ -1,0 +1,283 @@
+import logging
+import os
+import re
+import sqlite3
+
+
+# ---------------------------------------------------------------------------
+# Private helpers (copies of the equivalents in wa_media_archiver.py)
+# ---------------------------------------------------------------------------
+
+def _sanitize_filename(name: str) -> str:
+    return re.sub(r'[\\/:*?"<>|]', '_', name).strip()
+
+
+def _escape_like(s: str) -> str:
+    return s.replace('\\', '\\\\').replace('%', '\\%').replace('_', '\\_')
+
+
+def _format_phone(number: str) -> str:
+    return '00' + number if number else ''
+
+
+def _build_contact_folder_name(display_name: str, number: str) -> str:
+    formatted = _format_phone(number)
+    if not display_name or display_name == number:
+        label = f"Unknown ({formatted})"
+    else:
+        label = f"{display_name} ({formatted})"
+    return _sanitize_filename(label)
+
+
+# ---------------------------------------------------------------------------
+# Open / schema
+# ---------------------------------------------------------------------------
+
+def open_archive_db(output_root: str) -> sqlite3.Connection:
+    db_path = os.path.join(output_root, '.wa_media_archiver.db')
+    conn = sqlite3.connect(db_path)
+    conn.execute("PRAGMA journal_mode = WAL")
+    conn.execute("PRAGMA auto_vacuum = INCREMENTAL")
+    conn.execute("PRAGMA foreign_keys = ON")
+    conn.executescript("""
+        CREATE TABLE IF NOT EXISTS contacts (
+            number        TEXT PRIMARY KEY,
+            folder        TEXT NOT NULL,
+            display_name  TEXT NOT NULL DEFAULT ''
+        );
+        CREATE TABLE IF NOT EXISTS groups (
+            chat_row_id  TEXT PRIMARY KEY,
+            folder       TEXT NOT NULL,
+            subject      TEXT NOT NULL DEFAULT ''
+        );
+        CREATE TABLE IF NOT EXISTS files (
+            original_path  TEXT PRIMARY KEY,
+            md5            BLOB NOT NULL
+        );
+        CREATE TABLE IF NOT EXISTS archive_copies (
+            original_path  TEXT NOT NULL REFERENCES files(original_path),
+            archive_path   TEXT NOT NULL,
+            PRIMARY KEY (original_path, archive_path)
+        );
+        CREATE INDEX IF NOT EXISTS idx_files_md5 ON files(md5);
+    """)
+    return conn
+
+
+def check_db_health(conn: sqlite3.Connection, logger: logging.Logger):
+    results = conn.execute("PRAGMA quick_check").fetchall()
+    if results != [('ok',)]:
+        for row in results:
+            logger.error(f"Database integrity issue: {row[0]}")
+        raise SystemExit(1)
+
+    issues = conn.execute("PRAGMA foreign_key_check").fetchall()
+    if issues:
+        for table, rowid, parent, fkid in issues:
+            logger.error(
+                f"Foreign key violation in '{table}': rowid={rowid}, "
+                f"references '{parent}' (fk #{fkid})"
+            )
+        raise SystemExit(1)
+
+    logger.debug("Database health check passed.")
+
+
+# ---------------------------------------------------------------------------
+# Contacts persistence
+# ---------------------------------------------------------------------------
+
+def load_contacts_from_db(conn: sqlite3.Connection) -> dict:
+    return {row[0]: (row[1], row[2])
+            for row in conn.execute("SELECT number, folder, display_name FROM contacts")}
+
+
+def save_contacts_to_db(conn: sqlite3.Connection, index: dict):
+    conn.executemany(
+        "INSERT OR REPLACE INTO contacts (number, folder, display_name) VALUES (?, ?, ?)",
+        ((number, folder, display_name) for number, (folder, display_name) in index.items())
+    )
+
+
+# ---------------------------------------------------------------------------
+# Groups persistence
+# ---------------------------------------------------------------------------
+
+def load_groups_from_db(conn: sqlite3.Connection) -> dict:
+    return {
+        row[0]: {'folder': row[1], 'subject': row[2]}
+        for row in conn.execute(
+            "SELECT chat_row_id, folder, subject FROM groups"
+        )
+    }
+
+
+def save_groups_to_db(conn: sqlite3.Connection, index: dict):
+    conn.executemany(
+        "INSERT OR REPLACE INTO groups (chat_row_id, folder, subject) VALUES (?, ?, ?)",
+        ((key, val['folder'], val['subject']) for key, val in index.items())
+    )
+
+
+# ---------------------------------------------------------------------------
+# File archive tracking
+# ---------------------------------------------------------------------------
+
+def record_file_archived(cursor: sqlite3.Cursor,
+                         original_path: str, md5: bytes, archive_path: str):
+    cursor.execute(
+        "INSERT INTO files (original_path, md5) VALUES (?, ?) "
+        "ON CONFLICT(original_path) DO UPDATE SET md5 = excluded.md5",
+        (original_path, md5)
+    )
+    cursor.execute(
+        "INSERT OR IGNORE INTO archive_copies (original_path, archive_path) VALUES (?, ?)",
+        (original_path, archive_path)
+    )
+
+
+# ---------------------------------------------------------------------------
+# Folder name sync and resolution
+# ---------------------------------------------------------------------------
+
+def _unique_group_name(desired: str, existing: set) -> str:
+    if desired not in existing:
+        return desired
+    counter = 2
+    while True:
+        candidate = f"{desired} ({counter})"
+        if candidate not in existing:
+            return candidate
+        counter += 1
+
+
+def sync_group_names(group_subjects: dict, output_root: str,
+                     group_index: dict, logger: logging.Logger,
+                     conn: sqlite3.Connection | None = None,
+                     dry_run: bool = False) -> dict:
+    groups_root = os.path.join(output_root, 'Groups')
+    updated = dict(group_index)
+
+    for key, current_subject in group_subjects.items():
+        if key not in updated:
+            continue
+
+        entry = updated[key]
+        old_folder = entry['folder']
+        old_subject = entry.get('subject', '')
+
+        if current_subject == old_subject:
+            continue
+
+        desired = _sanitize_filename(current_subject) if current_subject \
+            else f"Unknown Group ({key})"
+        existing = {v['folder'] for k2, v in updated.items() if k2 != key}
+        new_folder = _unique_group_name(desired, existing)
+
+        old_path = os.path.join(groups_root, old_folder)
+        new_path = os.path.join(groups_root, new_folder)
+
+        if os.path.exists(old_path):
+            if os.path.exists(new_path):
+                logger.warning(
+                    f"RENAME skipped — target already exists: "
+                    f"{old_folder} -> {new_folder}"
+                )
+            else:
+                if dry_run:
+                    logger.info(f"[DRY RUN] Would rename group folder: {old_folder} -> {new_folder}")
+                    continue
+                else:
+                    os.rename(old_path, new_path)
+                    logger.info(f"RENAMED group folder: {old_folder} -> {new_folder}")
+                    if conn is not None:
+                        old_prefix = f"Groups/{old_folder}/"
+                        new_prefix = f"Groups/{new_folder}/"
+                        conn.execute(
+                            "UPDATE archive_copies "
+                            "SET archive_path = ? || SUBSTR(archive_path, ?) "
+                            "WHERE archive_path LIKE ? ESCAPE '\\'",
+                            (new_prefix, len(old_prefix) + 1,
+                             f"{_escape_like(old_prefix)}%")
+                        )
+        else:
+            logger.debug(
+                f"Group folder name changed but no folder on disk yet: "
+                f"{old_folder} -> {new_folder}"
+            )
+
+        updated[key] = {'folder': new_folder, 'subject': current_subject}
+
+    return updated
+
+
+def resolve_group_folder(chat_row_id: int, chat_subject: str | None,
+                         group_index: dict) -> str:
+    key = str(chat_row_id)
+    if key in group_index:
+        return group_index[key]['folder']
+
+    desired = _sanitize_filename(chat_subject) if chat_subject \
+        else f"Unknown Group ({chat_row_id})"
+    existing = {v['folder'] for v in group_index.values()}
+    folder = _unique_group_name(desired, existing)
+    group_index[key] = {'folder': folder, 'subject': chat_subject or ''}
+    return folder
+
+
+def sync_folder_names(contacts: dict, number_map: dict, output_root: str,
+                      folder_index: dict, logger: logging.Logger,
+                      conn: sqlite3.Connection | None = None,
+                      dry_run: bool = False) -> dict:
+    contacts_root = os.path.join(output_root, 'Contacts')
+    updated_index = dict(folder_index)
+
+    for number, display_name in contacts.items():
+        canonical = number_map.get(number, number)
+        new_folder = _build_contact_folder_name(display_name, canonical)
+        entry = folder_index.get(canonical)
+        old_folder = entry[0] if entry is not None else None
+
+        if old_folder is None:
+            updated_index[canonical] = (new_folder, display_name)
+            continue
+
+        if old_folder == new_folder:
+            updated_index[canonical] = (new_folder, display_name)
+            continue
+
+        old_path = os.path.join(contacts_root, old_folder)
+        new_path = os.path.join(contacts_root, new_folder)
+
+        if os.path.exists(old_path):
+            if os.path.exists(new_path):
+                logger.warning(
+                    f"RENAME skipped — target already exists: "
+                    f"{old_folder} -> {new_folder}"
+                )
+            else:
+                if dry_run:
+                    logger.info(f"[DRY RUN] Would rename contact folder: {old_folder} -> {new_folder}")
+                    continue
+                else:
+                    os.rename(old_path, new_path)
+                    logger.info(f"RENAMED contact folder: {old_folder} -> {new_folder}")
+                    if conn is not None:
+                        old_prefix = f"Contacts/{old_folder}/"
+                        new_prefix = f"Contacts/{new_folder}/"
+                        conn.execute(
+                            "UPDATE archive_copies "
+                            "SET archive_path = ? || SUBSTR(archive_path, ?) "
+                            "WHERE archive_path LIKE ? ESCAPE '\\'",
+                            (new_prefix, len(old_prefix) + 1,
+                             f"{_escape_like(old_prefix)}%")
+                        )
+        else:
+            logger.debug(
+                f"Folder name changed but no folder on disk yet: "
+                f"{old_folder} -> {new_folder}"
+            )
+
+        updated_index[canonical] = (new_folder, display_name)
+
+    return updated_index

--- a/backup_reader.py
+++ b/backup_reader.py
@@ -16,6 +16,17 @@ _WA_DOMAIN          = 'AppDomainGroup-group.net.whatsapp.WhatsApp.shared'
 _WA_BUSINESS_DOMAIN = 'AppDomainGroup-group.net.whatsapp.WhatsAppSMB.shared'
 
 
+def _raise_macos_fda_error(path: str, logger: logging.Logger) -> None:
+    logger.error(
+        f"Permission denied reading backup file — macOS blocked access to:\n"
+        f"  {path}\n"
+        f"Grant Full Disk Access to Terminal (or whichever app runs this script):\n"
+        f"  System Settings → Privacy & Security → Full Disk Access → enable Terminal\n"
+        f"Then re-run the command."
+    )
+    raise SystemExit(1)
+
+
 def detect_encrypted(backup_dir: str, logger: logging.Logger) -> bool:
     """
     Return True if the iPhone backup is encrypted.
@@ -41,8 +52,11 @@ def detect_encrypted(backup_dir: str, logger: logging.Logger) -> bool:
     else:
         plist_path = info_path
 
-    with open(plist_path, 'rb') as f:
-        data = plistlib.load(f)
+    try:
+        with open(plist_path, 'rb') as f:
+            data = plistlib.load(f)
+    except PermissionError:
+        _raise_macos_fda_error(plist_path, logger)
 
     # Manifest.plist uses 'IsEncrypted'; Info.plist does not carry this flag.
     # If we only have Info.plist, fall back to checking Manifest.plist if present.
@@ -50,8 +64,11 @@ def detect_encrypted(backup_dir: str, logger: logging.Logger) -> bool:
     if not is_encrypted and plist_path == info_path:
         manifest_path = os.path.join(backup_dir, 'Manifest.plist')
         if os.path.isfile(manifest_path):
-            with open(manifest_path, 'rb') as f:
-                manifest_data = plistlib.load(f)
+            try:
+                with open(manifest_path, 'rb') as f:
+                    manifest_data = plistlib.load(f)
+            except PermissionError:
+                _raise_macos_fda_error(manifest_path, logger)
             is_encrypted = manifest_data.get('IsEncrypted', False)
 
     return bool(is_encrypted)
@@ -81,6 +98,11 @@ def build_manifest_map(backup_dir: str,
         )
         raise SystemExit(1)
 
+    try:
+        with open(manifest_db, 'rb'):
+            pass
+    except PermissionError:
+        _raise_macos_fda_error(manifest_db, logger)
     with contextlib.closing(sqlite3.connect(manifest_db)) as conn:
         rows = conn.execute(
             "SELECT fileID, relativePath "

--- a/backup_reader.py
+++ b/backup_reader.py
@@ -134,7 +134,8 @@ def extract_to_temp(manifest_map: dict[str, str],
     if src is None:
         logger.error(
             f"'{relative_path}' not found in backup manifest.\n"
-            f"  This file may not exist in the WhatsApp domain of this backup."
+            f"  This file may not exist in the WhatsApp domain of this backup.\n"
+            f"  If you use WhatsApp Business, add --business to your command."
         )
         raise SystemExit(1)
 
@@ -258,7 +259,10 @@ def extract_encrypted(backup_dir: str,
                             domain_like=domain_like,
                             output_filename=tmp_db.name)
     except FileNotFoundError:
-        logger.error("ChatStorage.sqlite not found in encrypted backup.")
+        logger.error(
+            "ChatStorage.sqlite not found in encrypted backup.\n"
+            "  If you use WhatsApp Business, add --business to your command."
+        )
         os.unlink(tmp_db.name)
         raise SystemExit(1)
     msgstore_path = _save_db_to_output(tmp_db.name, output_dir, 'ChatStorage.sqlite', logger)

--- a/docs/prerequisites.md
+++ b/docs/prerequisites.md
@@ -99,7 +99,7 @@ Run the script with `--mode adb`:
 ```bash
 python3 wa_media_archiver.py \
   --mode adb \
-  --e2e your_cryptographic_key \
+  --e2e 1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0b1c2d3e4f5a6b7c8d9e0f1a2b \
   --wa_root /path/to/WhatsApp/storage \
   --output /path/to/output
 ```
@@ -154,7 +154,7 @@ Alternatively, skip the manual decrypt and let the script handle it by passing t
 ```bash
 python3 wa_media_archiver.py \
   --msgstore /path/to/msgstore.db.crypt15 \
-  --e2e your_cryptographic_key \
+  --e2e 1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0b1c2d3e4f5a6b7c8d9e0f1a2b \
   --wa_root /path/to/WhatsApp/storage \
   --output /path/to/output
 ```

--- a/docs/prerequisites.md
+++ b/docs/prerequisites.md
@@ -88,10 +88,13 @@ Pass the path to the `WhatsApp/` folder (not `Media/`) to the script via `--wa_r
 
 This is the simplest approach for most users. Connect your phone via USB with USB Debugging enabled, then let the script handle the pull and decryption automatically.
 
-> 💡 **ADB required.** Install it before running `--mode adb`:
-> - **Linux**: `sudo apt install adb` (Debian/Ubuntu) or `sudo dnf install android-tools` (Fedora)
-> - **macOS**: `brew install android-platform-tools` (requires [Homebrew](https://brew.sh))
-> - **Windows**: Download [Android Platform Tools](https://developer.android.com/tools/releases/platform-tools) and add the folder to your PATH
+ **ADB is required.** Install it before running this mode:
+- **Linux**: `sudo apt install adb` (Debian/Ubuntu) or `sudo dnf install android-tools` (Fedora)
+- **macOS**: `brew install android-platform-tools` (requires [Homebrew](https://brew.sh))
+- **Windows**: Install it using either:
+    - Winget (`winget install Google.PlatformTools`)
+    - Scoop (`scoop install main/adb`).
+    - Manual install [Android Platform Tools](https://developer.android.com/tools/releases/platform-tools), then add the folder to your PATH
 
 Run the script with `--mode adb`:
 

--- a/docs/prerequisites.md
+++ b/docs/prerequisites.md
@@ -93,7 +93,7 @@ This is the simplest approach for most users. Connect your phone via USB with US
 - **macOS**: `brew install android-platform-tools` (requires [Homebrew](https://brew.sh))
 - **Windows**: Install it using either:
     - Winget (`winget install Google.PlatformTools`)
-    - Scoop (`scoop install main/adb`).
+    - Scoop (`scoop install main/adb`)
     - Manual install [Android Platform Tools](https://developer.android.com/tools/releases/platform-tools), then add the folder to your PATH
 
 Run the script with `--mode adb`:

--- a/docs/prerequisites.md
+++ b/docs/prerequisites.md
@@ -9,8 +9,6 @@ This script relies on some packages for Android and iOS.
 
 Install the relevant package before your first run. If you miss any of these, the script will notify you.
 
-
-
 **Android encrypted backup decryption** 
 
 The script uses `wa-crypt-tools`. You are going to use it if you don't have a rooted device.
@@ -64,7 +62,6 @@ When asked, create the end-to-end ecrypted backup.
 
 ## 3. Android Setup
 
-
 ### Your WhatsApp Media Folder
 
 Before you run the script, you need your WhatsApp (Media) folder on disk - actually, the folder called `WhatsApp` that **contains** the `Media` subfolder. 
@@ -83,7 +80,9 @@ Pass the path to the `WhatsApp/` folder (not `Media/`) to the script via `--wa_r
 
 > ⚠️ **Run the script on the same machine where the media files are physically stored.** Processing files over a network share (NFS, SMB, etc.) will be significantly slower — the script hashes and copies every file in the archive. Running locally is strongly recommended.
 
-### Obtaining the Database
+### Obtaining the Database and running the Script
+
+> 💡 If you always run with the same settings, you can save them in a config.toml file instead — see docs/running-the-script.md.
 
 #### Recommended — Automatic Retrieval (`--mode adb`)
 
@@ -223,6 +222,8 @@ C:\Users\<Username>\Apple\MobileSync\Backup\<UDID>\
 The backup directory is the folder that contains `Manifest.db`. Pass it to `--ios_backup`.
 
 ### Step 3 — Run the script
+
+> 💡 If you always run with the same settings, you can save them in a config.toml file instead — see docs/running-the-script.md.
 
 Unencrypted backup:
 

--- a/docs/prerequisites.md
+++ b/docs/prerequisites.md
@@ -3,7 +3,7 @@
 
 ## 1. Python Environment
 
-Ensure Python 3.10+ is installed.
+Ensure Python 3.11+ is installed.
 
 This script relies on some packages for Android and iOS.
 

--- a/docs/running-the-script.md
+++ b/docs/running-the-script.md
@@ -83,6 +83,12 @@ output     = "/path/to/archive"
 # ios_contacts = ""
 ```
 
+> ⚠️ **Windows users:** TOML does not allow single backslashes in strings — use forward slashes or double backslashes for paths:
+> ```toml
+> output = "C:/Users/Oliver/Desktop/archive"      # forward slashes — recommended
+> output = "C:\\Users\\Oliver\\Desktop\\archive"  # double backslashes also work
+> ```
+
 ### How the config file is found
 
 1. **Explicit path** — pass `--config /path/to/myconfig.toml`. No confirmation prompt.

--- a/docs/running-the-script.md
+++ b/docs/running-the-script.md
@@ -83,7 +83,7 @@ output     = "/path/to/archive"
 # ios_contacts = ""
 ```
 
-> 💡 **Windows users:** TOML does not allow single backslashes in strings. If you paste a Windows path like `C:\Users\...` the script will automatically convert the backslashes to forward slashes and continue, printing a warning. Update the file to use forward slashes (`C:/Users/...`) to suppress the warning.
+> 💡 **Windows users:** You can paste Windows paths directly (e.g. `C:\Users\...`). If the path contains backslashes the script will automatically convert them to forward slashes and update the config file in place — no manual editing needed.
 
 ### How the config file is found
 

--- a/docs/running-the-script.md
+++ b/docs/running-the-script.md
@@ -46,18 +46,6 @@ usage: wa_media_archiver.py [-h]
 
 ---
 
-## Line Continuation by Shell
-
-The examples below use `\` to split long commands across multiple lines. Replace it with the correct character for your shell:
-
-| Shell | Character |
-|---|---|
-| bash / zsh (Linux, macOS) | `\` |
-| PowerShell (Windows) | `` ` `` |
-| cmd.exe (Windows) | `^` |
-
----
-
 ## Config File
 
 If you always run the script with the same paths and settings, you can save them in a `config.toml` file instead of repeating them on the command line every time.
@@ -108,6 +96,17 @@ output     = "/path/to/archive"
 CLI arguments always win. A value set in `config.toml` acts as a default and is overridden by anything explicitly passed on the command line.
 
 `--dry-run` and `--limit` are intentionally excluded from the config file — they are one-off flags and can always be appended to the command line.
+
+---
+## Line Continuation by Shell
+
+The examples below use `\` to split long commands across multiple lines. Replace it with the correct character for your shell:
+
+| Shell | Character |
+|---|---|
+| bash / zsh (Linux, macOS) | `\` |
+| PowerShell (Windows) | `` ` `` |
+| cmd.exe (Windows) | `^` |
 
 ---
 

--- a/docs/running-the-script.md
+++ b/docs/running-the-script.md
@@ -48,7 +48,7 @@ usage: wa_media_archiver.py [-h]
 
 ## Config File
 
-If you always run the script with the same paths and settings, you can save them in a `config.toml` file instead of repeating them on the command line every time.
+The config file is the easiest way to run (and re-run) your script: instead of repeating settings on the command line every time, they are saved in a `config.toml` file .
 
 ### Generating the example file
 
@@ -99,10 +99,14 @@ CLI arguments always win. A value set in `config.toml` acts as a default and is 
 
 `--dry-run` and `--limit` are intentionally excluded from the config file — they are one-off flags and can always be appended to the command line.
 
----
-## Line Continuation by Shell
 
-The examples below use `\` to split long commands across multiple lines. Replace it with the correct character for your shell:
+---
+
+## CLI Arguments
+
+If you prefer to run the script the traditional way, you can find some examples below. Please note they are not covering all possible cases.
+
+> 💡The examples below use `\` to split long commands across multiple lines. Replace it with the correct character for your shell:
 
 | Shell | Character |
 |---|---|
@@ -110,9 +114,6 @@ The examples below use `\` to split long commands across multiple lines. Replace
 | PowerShell (Windows) | `` ` `` |
 | cmd.exe (Windows) | `^` |
 
----
-
-## Usage Examples
 
 ### Android
 
@@ -157,7 +158,7 @@ python3 wa_media_archiver.py \
 
 ### iOS
 
-#### Standard flow — unencrypted backup (recommended)
+#### Standard flow — unencrypted backup
 
 ```bash
 python3 wa_media_archiver.py \
@@ -166,7 +167,7 @@ python3 wa_media_archiver.py \
   --dry-run
 ```
 
-#### Encrypted backup
+#### Standard flow - encrypted backup
 
 ```bash
 python3 wa_media_archiver.py \
@@ -195,6 +196,7 @@ python3 wa_media_archiver.py \
 ```
 
 #### iOS — pre-extracted mode
+Only use this mode with iOS if you know what you're doing.
 
 ```bash
 python3 wa_media_archiver.py \
@@ -203,17 +205,6 @@ python3 wa_media_archiver.py \
   --ios_contacts /path/to/ContactsV2.sqlite \
   --output /path/to/output
 ```
-
-#### Restore original Media/ folder structure
-
-```bash
-python3 wa_media_archiver.py \
-  --mode restore \
-  --output /path/to/output
-```
-
-> 💡 `--wa_root` is not required in restore mode. The script reads `.wa_media_archiver.db` from the archive and reconstructs `<output>/Media/` in place. Use `--dry-run` to preview what would be written.
-> ⚠️ Restore mode is supported for **Android archives only**. Running it against an iOS archive exits with a clear error.
 
 ---
 
@@ -234,6 +225,12 @@ python3 wa_media_archiver.py \
 Restore mode reconstructs the flat `WhatsApp/Media/` folder structure directly inside the archive folder, without needing the original device or database. This is useful when re-importing media into tools that expect the original WhatsApp layout.
 
 > ⚠️ **Android archives only.** iOS media is stored at `Message/Media/...` paths that have no equivalent reconstruction target outside the iPhone backup format. Running restore mode on an iOS archive is disallowed.
+
+```bash
+python3 wa_media_archiver.py \
+  --mode restore \
+  --output /path/to/output
+```
 
 The reconstructed tree is written to `<output>/Media/`, alongside the existing `Contacts/` and `Groups/` folders. No files are overwritten — identical files already in place are skipped silently.
 

--- a/docs/running-the-script.md
+++ b/docs/running-the-script.md
@@ -119,7 +119,7 @@ The examples below use `\` to split long commands across multiple lines. Replace
 ```bash
 python3 wa_media_archiver.py \
   --mode adb \
-  --e2e your_cryptographic_key \
+  --e2e 1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0b1c2d3e4f5a6b7c8d9e0f1a2b \
   --wa_root /path/to/WhatsApp/storage \
   --output /path/to/output \
   --dry-run
@@ -143,7 +143,7 @@ python3 wa_media_archiver.py \
 ```bash
 python3 wa_media_archiver.py \
   --msgstore /path/to/msgstore.db.crypt15 \
-  --e2e your_cryptographic_key \
+  --e2e 1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0b1c2d3e4f5a6b7c8d9e0f1a2b \
   --wa_root /path/to/WhatsApp/storage \
   --output /path/to/output \
   --dry-run

--- a/docs/running-the-script.md
+++ b/docs/running-the-script.md
@@ -83,11 +83,7 @@ output     = "/path/to/archive"
 # ios_contacts = ""
 ```
 
-> ⚠️ **Windows users:** TOML does not allow single backslashes in strings — use forward slashes or double backslashes for paths:
-> ```toml
-> output = "C:/Users/Oliver/Desktop/archive"      # forward slashes — recommended
-> output = "C:\\Users\\Oliver\\Desktop\\archive"  # double backslashes also work
-> ```
+> 💡 **Windows users:** TOML does not allow single backslashes in strings. If you paste a Windows path like `C:\Users\...` the script will automatically convert the backslashes to forward slashes and continue, printing a warning. Update the file to use forward slashes (`C:/Users/...`) to suppress the warning.
 
 ### How the config file is found
 

--- a/docs/running-the-script.md
+++ b/docs/running-the-script.md
@@ -5,6 +5,8 @@
 
 ```
 usage: wa_media_archiver.py [-h]
+                      [--config PATH]
+                      [--generate-config]
                       [-msg MSGSTORE]
                       [-e2e E2E_KEY]
                       [-c CONTACTS]
@@ -24,6 +26,8 @@ usage: wa_media_archiver.py [-h]
 
 | Argument | Required | Description |
 |---|---|---|
+| `--config PATH` | No | Path to a TOML config file. If omitted, the script auto-detects `config.toml` in the script folder or current directory |
+| `--generate-config` | No | Write `example-config.toml` to the script folder and exit. Rename it to `config.toml` to activate it |
 | `-msg` / `--msgstore` | No | Path to `msgstore.db`, `msgstore.db.crypt15`, or `ChatStorage.sqlite`. Not needed with `--ios_backup`. Defaults to `msgstore.db` in the current folder |
 | `-e2e` / `--e2e_key` | If encrypted | Your cryptographic key for `.crypt15` decryption |
 | `-c` / `--contacts` | No | Path to the `wa_contacts` file exported via ADB (Android only) |
@@ -51,6 +55,59 @@ The examples below use `\` to split long commands across multiple lines. Replace
 | bash / zsh (Linux, macOS) | `\` |
 | PowerShell (Windows) | `` ` `` |
 | cmd.exe (Windows) | `^` |
+
+---
+
+## Config File
+
+If you always run the script with the same paths and settings, you can save them in a `config.toml` file instead of repeating them on the command line every time.
+
+### Generating the example file
+
+```bash
+python3 wa_media_archiver.py --generate-config
+```
+
+This writes `example-config.toml` next to the script. Open it, fill in your values, then rename it to `config.toml`.
+
+### Format
+
+```toml
+# wa_media_archiver config
+# All paths can be absolute or relative to where you run the script.
+
+output     = "/path/to/archive"
+
+# Optional settings — uncomment to activate:
+# msgstore  = "msgstore.db"
+# e2e_key   = ""
+# wa_root   = ""
+# contacts  = ""
+# log       = ""
+# mode      = ""          # "adb" or "restore"
+# business  = false
+# timezone  = ""          # e.g. Europe/Rome
+# since     = ""          # e.g. 2024-01-01
+
+# iOS
+# ios_backup   = ""
+# ios_password = ""
+# ios_contacts = ""
+```
+
+### How the config file is found
+
+1. **Explicit path** — pass `--config /path/to/myconfig.toml`. No confirmation prompt.
+2. **Auto-detection** — the script checks for `config.toml` in the script folder and the current directory:
+   - Exactly one found → confirmation prompt `Found config.toml at <path> — use it? [Y/n]`
+   - Two found → error; use `--config` to specify which one
+   - None found → config file ignored, CLI args only
+
+### Precedence
+
+CLI arguments always win. A value set in `config.toml` acts as a default and is overridden by anything explicitly passed on the command line.
+
+`--dry-run` and `--limit` are intentionally excluded from the config file — they are one-off flags and can always be appended to the command line.
 
 ---
 

--- a/icon.svg
+++ b/icon.svg
@@ -1,0 +1,31 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="200" height="200">
+  <!-- App icon background -->
+  <rect width="200" height="200" rx="44" fill="#1e293b"/>
+
+  <!-- Archive box body (touch smaller) -->
+  <rect x="38" y="100" width="124" height="78" rx="6" fill="#e2e8f0"/>
+  <!-- Archive box lid -->
+  <rect x="30" y="78" width="140" height="26" rx="6" fill="#cbd5e1"/>
+  <!-- Lid clasp -->
+  <rect x="76" y="84" width="48" height="12" rx="6" fill="#94a3b8"/>
+
+  <!-- Chat bubble (larger, top-right) -->
+  <path d="M90,12 Q90,4 100,4 L182,4 Q190,4 190,12 L190,78 Q190,86 182,86 L148,86 L136,102 L140,86 L100,86 Q90,86 90,78 Z" fill="#22c55e"/>
+
+  <!-- Three stacked photo thumbnails -->
+
+  <!-- Photo 3 (back) -->
+  <rect x="116" y="24" width="56" height="42" rx="3" fill="#166534"/>
+
+  <!-- Photo 2 (middle) -->
+  <rect x="110" y="18" width="56" height="42" rx="3" fill="#15803d"/>
+
+  <!-- Photo 1 (front) -->
+  <rect x="104" y="12" width="56" height="42" rx="3" fill="white" opacity="0.95"/>
+  <!-- Sky -->
+  <rect x="104" y="12" width="56" height="42" rx="3" fill="#bfdbfe" opacity="0.55"/>
+  <!-- Mountain -->
+  <polygon points="104,54 122,34 134,44 146,36 160,54" fill="white" opacity="0.95"/>
+  <!-- Sun -->
+  <circle cx="152" cy="21" r="6" fill="white" opacity="0.95"/>
+</svg>

--- a/ios_handler.py
+++ b/ios_handler.py
@@ -93,6 +93,7 @@ def build_ios_group_subjects_query() -> str:
         WHERE cs.ZGROUPINFO IS NOT NULL
           AND cs.ZPARTNERNAME IS NOT NULL
           AND mi.ZMEDIALOCALPATH IS NOT NULL
+          AND mi.ZMEDIALOCALPATH NOT LIKE '%@status%'
     """
 
 
@@ -147,6 +148,7 @@ SELECT * FROM (
         LEFT JOIN ZWAGROUPMEMBER gm ON gm.Z_PK = m.ZGROUPMEMBER
         WHERE cs.ZGROUPINFO IS NOT NULL
           AND mi.ZMEDIALOCALPATH IS NOT NULL
+          AND mi.ZMEDIALOCALPATH NOT LIKE '%@status%'
           AND cs.ZPARTNERNAME IS NOT NULL
           {since_clause}
         {block_limit_clause}
@@ -175,6 +177,7 @@ SELECT * FROM (
         JOIN ZWAMEDIAITEM   mi ON mi.Z_PK = m.ZMEDIAITEM
         WHERE cs.ZGROUPINFO IS NULL
           AND mi.ZMEDIALOCALPATH IS NOT NULL
+          AND mi.ZMEDIALOCALPATH NOT LIKE '%@status%'
           {since_clause}
         {block_limit_clause}
     )

--- a/tests/test_wa_media_archiver.py
+++ b/tests/test_wa_media_archiver.py
@@ -1977,10 +1977,10 @@ class TestLoadToml:
 
     def test_windows_backslash_path_auto_corrected(self, tmp_path, capsys):
         cfg = tmp_path / "config.toml"
-        cfg.write_bytes(b'output = "C:\\Users\\Oliver\\Desktop\\archive"\n')
+        cfg.write_bytes(b'output = "C:\\Users\\User\\Desktop\\archive"\n')
         result = wa._load_toml(str(cfg))
-        assert result["output"] == "C:/Users/Oliver/Desktop/archive"
-        assert 'output = "C:/Users/Oliver/Desktop/archive"' in cfg.read_text(encoding='utf-8')
+        assert result["output"] == "C:/Users/User/Desktop/archive"
+        assert 'output = "C:/Users/User/Desktop/archive"' in cfg.read_text(encoding='utf-8')
         captured = capsys.readouterr()
         assert "NOTE" in captured.err
 

--- a/tests/test_wa_media_archiver.py
+++ b/tests/test_wa_media_archiver.py
@@ -1980,9 +1980,9 @@ class TestLoadToml:
         cfg.write_bytes(b'output = "C:\\Users\\Oliver\\Desktop\\archive"\n')
         result = wa._load_toml(str(cfg))
         assert result["output"] == "C:/Users/Oliver/Desktop/archive"
+        assert 'output = "C:/Users/Oliver/Desktop/archive"' in cfg.read_text(encoding='utf-8')
         captured = capsys.readouterr()
-        assert "WARNING" in captured.err
-        assert "forward slashes" in captured.err
+        assert "NOTE" in captured.err
 
     def test_genuinely_invalid_toml_exits(self, tmp_path):
         cfg = tmp_path / "config.toml"

--- a/tests/test_wa_media_archiver.py
+++ b/tests/test_wa_media_archiver.py
@@ -1952,3 +1952,125 @@ class TestCheckDependencies:
         assert len(errors) == 1, "Expected a single combined error message"
         assert "adb" in errors[0]
         assert "wa-crypt-tools" in errors[0]
+
+
+# ===========================================================================
+# Config file
+# ===========================================================================
+
+class TestLoadToml:
+    def test_valid_toml_returns_dict(self, tmp_path):
+        cfg = tmp_path / "config.toml"
+        cfg.write_text('output = "/tmp/archive"\n', encoding='utf-8')
+        result = wa._load_toml(str(cfg))
+        assert result == {"output": "/tmp/archive"}
+
+    def test_syntax_error_exits(self, tmp_path):
+        cfg = tmp_path / "config.toml"
+        cfg.write_text('output = [unclosed\n', encoding='utf-8')
+        with pytest.raises(SystemExit):
+            wa._load_toml(str(cfg))
+
+    def test_missing_file_exits(self, tmp_path):
+        with pytest.raises(SystemExit):
+            wa._load_toml(str(tmp_path / "nonexistent.toml"))
+
+
+class TestGenerateConfig:
+    def test_writes_example_config(self, tmp_path):
+        with pytest.raises(SystemExit):
+            wa._generate_config(str(tmp_path))
+        dest = tmp_path / "example-config.toml"
+        assert dest.exists()
+        content = dest.read_text(encoding='utf-8')
+        assert "config.toml" in content
+        assert "output" in content
+
+    def test_overwrites_existing_file(self, tmp_path):
+        dest = tmp_path / "example-config.toml"
+        dest.write_text("old content", encoding='utf-8')
+        with pytest.raises(SystemExit):
+            wa._generate_config(str(tmp_path))
+        assert "old content" not in dest.read_text(encoding='utf-8')
+
+
+class TestConfigInParseArgs:
+    """Integration tests that exercise config loading through parse_args()."""
+
+    def _write_config(self, path, content):
+        with open(path, 'w', encoding='utf-8') as f:
+            f.write(content)
+
+    @staticmethod
+    def _toml_path(p):
+        """Convert a path to forward-slash form for safe TOML string literals."""
+        return str(p).replace('\\', '/')
+
+    def test_config_values_used_as_defaults(self, tmp_path):
+        cfg = tmp_path / "config.toml"
+        out = self._toml_path(tmp_path)
+        self._write_config(cfg, f'output = "{out}"\nwa_root = "/wa"\n')
+        with patch("sys.argv", ["wa", "--config", str(cfg)]):
+            args = wa.parse_args()
+        assert args.wa_root == "/wa"
+
+    def test_cli_overrides_config(self, tmp_path):
+        cfg = tmp_path / "config.toml"
+        self._write_config(cfg, 'output = "/from/config"\n')
+        out = self._toml_path(tmp_path)
+        with patch("sys.argv", ["wa", "--config", str(cfg),
+                                 "-o", str(tmp_path), "--wa_root", "/cli"]):
+            args = wa.parse_args()
+        assert args.output == str(tmp_path)
+
+    def test_unknown_key_exits(self, tmp_path):
+        cfg = tmp_path / "config.toml"
+        out = self._toml_path(tmp_path)
+        self._write_config(cfg, f'output = "{out}"\ntypo_key = "bad"\n')
+        with patch("sys.argv", ["wa", "--config", str(cfg)]):
+            with pytest.raises(SystemExit):
+                wa.parse_args()
+
+    def test_since_accepted_in_config(self, tmp_path):
+        cfg = tmp_path / "config.toml"
+        out = self._toml_path(tmp_path)
+        self._write_config(cfg, f'output = "{out}"\nwa_root = "/wa"\nsince = "2024-01-01"\n')
+        with patch("sys.argv", ["wa", "--config", str(cfg)]):
+            args = wa.parse_args()
+        assert args.since == "2024-01-01"
+
+    def test_autodetect_single_config_yes(self, tmp_path):
+        cfg = tmp_path / "config.toml"
+        out = self._toml_path(tmp_path)
+        self._write_config(cfg, f'output = "{out}"\nwa_root = "/wa"\n')
+        with patch("sys.argv", ["wa"]), \
+             patch("os.path.dirname", return_value=str(tmp_path)), \
+             patch("os.getcwd", return_value=str(tmp_path)), \
+             patch("builtins.input", return_value="y"):
+            args = wa.parse_args()
+        assert args.wa_root == "/wa"
+
+    def test_autodetect_single_config_no(self, tmp_path):
+        cfg = tmp_path / "config.toml"
+        self._write_config(cfg, 'output = "/from/config"\nwa_root = "/wa"\n')
+        out = self._toml_path(tmp_path)
+        with patch("sys.argv", ["wa", "-o", str(tmp_path), "--wa_root", "/cli"]), \
+             patch("os.path.dirname", return_value=str(tmp_path)), \
+             patch("os.getcwd", return_value="/different/dir"), \
+             patch("builtins.input", return_value="n"):
+            args = wa.parse_args()
+        # Config was declined; output comes from CLI
+        assert args.output == str(tmp_path)
+
+    def test_autodetect_two_configs_exits(self, tmp_path):
+        dir1 = tmp_path / "dir1"
+        dir2 = tmp_path / "dir2"
+        dir1.mkdir()
+        dir2.mkdir()
+        self._write_config(dir1 / "config.toml", 'output = "/a"\n')
+        self._write_config(dir2 / "config.toml", 'output = "/b"\n')
+        with patch("sys.argv", ["wa"]), \
+             patch("os.path.dirname", return_value=str(dir1)), \
+             patch("os.getcwd", return_value=str(dir2)):
+            with pytest.raises(SystemExit):
+                wa.parse_args()

--- a/tests/test_wa_media_archiver.py
+++ b/tests/test_wa_media_archiver.py
@@ -1971,23 +1971,24 @@ class TestLoadToml:
         result = wa._load_toml(str(cfg))
         assert result == {"output": "/tmp/archive"}
 
-    def test_syntax_error_exits(self, tmp_path):
-        cfg = tmp_path / "config.toml"
-        cfg.write_text('output = [unclosed\n', encoding='utf-8')
-        with pytest.raises(SystemExit):
-            wa._load_toml(str(cfg))
-
     def test_missing_file_exits(self, tmp_path):
         with pytest.raises(SystemExit):
             wa._load_toml(str(tmp_path / "nonexistent.toml"))
 
-    def test_windows_backslash_path_shows_hint(self, tmp_path, capsys):
+    def test_windows_backslash_path_auto_corrected(self, tmp_path, capsys):
         cfg = tmp_path / "config.toml"
         cfg.write_bytes(b'output = "C:\\Users\\Oliver\\Desktop\\archive"\n')
+        result = wa._load_toml(str(cfg))
+        assert result["output"] == "C:/Users/Oliver/Desktop/archive"
+        captured = capsys.readouterr()
+        assert "WARNING" in captured.err
+        assert "forward slashes" in captured.err
+
+    def test_genuinely_invalid_toml_exits(self, tmp_path):
+        cfg = tmp_path / "config.toml"
+        cfg.write_text('output = [unclosed\n', encoding='utf-8')
         with pytest.raises(SystemExit):
             wa._load_toml(str(cfg))
-        captured = capsys.readouterr()
-        assert "forward slashes" in captured.err
 
 
 class TestGenerateConfig:

--- a/tests/test_wa_media_archiver.py
+++ b/tests/test_wa_media_archiver.py
@@ -1981,6 +1981,14 @@ class TestLoadToml:
         with pytest.raises(SystemExit):
             wa._load_toml(str(tmp_path / "nonexistent.toml"))
 
+    def test_windows_backslash_path_shows_hint(self, tmp_path, capsys):
+        cfg = tmp_path / "config.toml"
+        cfg.write_bytes(b'output = "C:\\Users\\Oliver\\Desktop\\archive"\n')
+        with pytest.raises(SystemExit):
+            wa._load_toml(str(cfg))
+        captured = capsys.readouterr()
+        assert "forward slashes" in captured.err
+
 
 class TestGenerateConfig:
     def test_writes_example_config(self, tmp_path):

--- a/tests/test_wa_media_archiver.py
+++ b/tests/test_wa_media_archiver.py
@@ -1983,6 +1983,9 @@ class TestLoadToml:
         assert 'output = "C:/Users/User/Desktop/archive"' in cfg.read_text(encoding='utf-8')
         captured = capsys.readouterr()
         assert "NOTE" in captured.err
+        # File must parse cleanly on a second load (no double line endings introduced)
+        result2 = wa._load_toml(str(cfg))
+        assert result2["output"] == "C:/Users/User/Desktop/archive"
 
     def test_genuinely_invalid_toml_exits(self, tmp_path):
         cfg = tmp_path / "config.toml"

--- a/tests/test_wa_media_archiver.py
+++ b/tests/test_wa_media_archiver.py
@@ -60,6 +60,12 @@ _adb_spec = _ilu.spec_from_file_location(
 adb = _ilu.module_from_spec(_adb_spec)
 _adb_spec.loader.exec_module(adb)
 
+_archive_db_spec = _ilu.spec_from_file_location(
+    "archive_db", os.path.join(_ROOT, "archive_db.py")
+)
+arc = _ilu.module_from_spec(_archive_db_spec)
+_archive_db_spec.loader.exec_module(arc)
+
 
 # ---------------------------------------------------------------------------
 # Shared fixture: a silent logger so test output stays clean
@@ -195,15 +201,15 @@ class TestAppendSenderToFilename:
 
 class TestUniqueGroupName:
     def test_unused_name_returned_as_is(self):
-        assert wa._unique_group_name("Family", set()) == "Family"
-        assert wa._unique_group_name("Family", {"Other"}) == "Family"
+        assert arc._unique_group_name("Family", set()) == "Family"
+        assert arc._unique_group_name("Family", {"Other"}) == "Family"
 
     def test_collision_gets_counter_suffix(self):
-        assert wa._unique_group_name("Family", {"Family"}) == "Family (2)"
+        assert arc._unique_group_name("Family", {"Family"}) == "Family (2)"
 
     def test_multiple_collisions(self):
         existing = {"Family", "Family (2)", "Family (3)"}
-        assert wa._unique_group_name("Family", existing) == "Family (4)"
+        assert arc._unique_group_name("Family", existing) == "Family (4)"
 
 
 # ===========================================================================
@@ -956,30 +962,30 @@ class TestExtractEncrypted:
 class TestResolveGroupFolder:
     def test_new_group_assigned_sanitized_name(self):
         index = {}
-        folder = wa.resolve_group_folder('42', 'Family Chat', index)
+        folder = arc.resolve_group_folder('42', 'Family Chat', index)
         assert folder == 'Family Chat'
         assert index['42']['folder'] == 'Family Chat'
 
     def test_existing_group_returns_stable_name(self):
         # Even if subject has changed, the stable folder from the index is returned.
         index = {'42': {'folder': 'OldName', 'subject': 'OldName'}}
-        folder = wa.resolve_group_folder('42', 'NewName', index)
+        folder = arc.resolve_group_folder('42', 'NewName', index)
         assert folder == 'OldName'
 
     def test_none_subject_gets_unknown_fallback(self):
         index = {}
-        folder = wa.resolve_group_folder('99', None, index)
+        folder = arc.resolve_group_folder('99', None, index)
         assert 'Unknown Group' in folder
         assert '99' in folder
 
     def test_name_collision_with_existing_group_disambiguated(self):
         index = {'10': {'folder': 'Friends', 'subject': 'Friends'}}
-        folder = wa.resolve_group_folder('20', 'Friends', index)
+        folder = arc.resolve_group_folder('20', 'Friends', index)
         assert folder == 'Friends (2)'
 
     def test_special_chars_in_subject_sanitized(self):
         index = {}
-        folder = wa.resolve_group_folder('1', 'Chat: Family/Work', index)
+        folder = arc.resolve_group_folder('1', 'Chat: Family/Work', index)
         assert '/' not in folder
         assert ':' not in folder
 
@@ -990,10 +996,10 @@ class TestResolveGroupFolder:
 
 class TestRecordFileArchived:
     def test_creates_file_and_copy_records(self, tmp_path):
-        conn = wa.open_archive_db(str(tmp_path))
+        conn = arc.open_archive_db(str(tmp_path))
         cursor = conn.cursor()
         md5 = b'\x01' * 16
-        wa.record_file_archived(cursor, 'orig.jpg', md5,
+        arc.record_file_archived(cursor, 'orig.jpg', md5,
                                 'Contacts/Alice (00111)/2024/Received/orig.jpg')
         conn.commit()
         row = conn.execute(
@@ -1007,11 +1013,11 @@ class TestRecordFileArchived:
         conn.close()
 
     def test_duplicate_archive_path_silently_ignored(self, tmp_path):
-        conn = wa.open_archive_db(str(tmp_path))
+        conn = arc.open_archive_db(str(tmp_path))
         cursor = conn.cursor()
         md5 = b'\x01' * 16
-        wa.record_file_archived(cursor, 'orig.jpg', md5, 'Contacts/path.jpg')
-        wa.record_file_archived(cursor, 'orig.jpg', md5, 'Contacts/path.jpg')
+        arc.record_file_archived(cursor, 'orig.jpg', md5, 'Contacts/path.jpg')
+        arc.record_file_archived(cursor, 'orig.jpg', md5, 'Contacts/path.jpg')
         conn.commit()
         count = conn.execute(
             "SELECT COUNT(*) FROM archive_copies WHERE original_path = 'orig.jpg'"
@@ -1020,11 +1026,11 @@ class TestRecordFileArchived:
         conn.close()
 
     def test_multiple_archive_paths_for_same_original(self, tmp_path):
-        conn = wa.open_archive_db(str(tmp_path))
+        conn = arc.open_archive_db(str(tmp_path))
         cursor = conn.cursor()
         md5 = b'\x01' * 16
-        wa.record_file_archived(cursor, 'orig.jpg', md5, 'path1.jpg')
-        wa.record_file_archived(cursor, 'orig.jpg', md5, 'path2.jpg')
+        arc.record_file_archived(cursor, 'orig.jpg', md5, 'path1.jpg')
+        arc.record_file_archived(cursor, 'orig.jpg', md5, 'path2.jpg')
         conn.commit()
         count = conn.execute(
             "SELECT COUNT(*) FROM archive_copies WHERE original_path = 'orig.jpg'"
@@ -1035,8 +1041,8 @@ class TestRecordFileArchived:
 
 class TestCheckDbHealth:
     def test_healthy_db_passes(self, tmp_path, logger):
-        conn = wa.open_archive_db(str(tmp_path))
-        wa.check_db_health(conn, logger)  # should not raise
+        conn = arc.open_archive_db(str(tmp_path))
+        arc.check_db_health(conn, logger)  # should not raise
         conn.close()
 
 
@@ -1075,7 +1081,7 @@ class TestWriteMissingReport:
 
 class TestWriteDuplicateReport:
     def test_no_duplicates_does_not_create_file(self, tmp_path, logger):
-        conn = wa.open_archive_db(str(tmp_path))
+        conn = arc.open_archive_db(str(tmp_path))
         path = str(tmp_path / 'dups.csv')
         wa.write_duplicate_report(path, conn, logger)
         conn.close()
@@ -1083,7 +1089,7 @@ class TestWriteDuplicateReport:
 
     def test_duplicates_written_to_csv(self, tmp_path, logger):
         import hashlib
-        conn = wa.open_archive_db(str(tmp_path))
+        conn = arc.open_archive_db(str(tmp_path))
         cursor = conn.cursor()
         md5 = hashlib.md5(b'data').digest()
         cursor.execute("INSERT INTO files VALUES (?, ?)", ('orig.jpg', md5))
@@ -1113,7 +1119,7 @@ class TestSyncFolderNames:
         (contacts_root / 'Alice (00111)').mkdir()
         folder_index = {'111': ('Alice (00111)', 'Alice')}
         contacts = {'111': 'Alice'}
-        result = wa.sync_folder_names(
+        result = arc.sync_folder_names(
             contacts, {}, str(tmp_path), folder_index, logger
         )
         assert result['111'][0] == 'Alice (00111)'
@@ -1125,7 +1131,7 @@ class TestSyncFolderNames:
         (contacts_root / 'OldName (00111)').mkdir()
         folder_index = {'111': ('OldName (00111)', 'OldName')}
         contacts = {'111': 'NewName'}
-        result = wa.sync_folder_names(
+        result = arc.sync_folder_names(
             contacts, {}, str(tmp_path), folder_index, logger
         )
         assert result['111'][0] == 'NewName (00111)'
@@ -1139,7 +1145,7 @@ class TestSyncFolderNames:
         (contacts_root / 'NewName (00111)').mkdir()  # target already exists
         folder_index = {'111': ('OldName (00111)', 'OldName')}
         contacts = {'111': 'NewName'}
-        result = wa.sync_folder_names(
+        result = arc.sync_folder_names(
             contacts, {}, str(tmp_path), folder_index, logger
         )
         # Index is updated to the new name even though the on-disk rename was skipped,
@@ -1150,13 +1156,13 @@ class TestSyncFolderNames:
         # Name changed but folder has never been created; index should update anyway
         folder_index = {'111': ('OldName (00111)', 'OldName')}
         contacts = {'111': 'NewName'}
-        result = wa.sync_folder_names(
+        result = arc.sync_folder_names(
             contacts, {}, str(tmp_path), folder_index, logger
         )
         assert result['111'][0] == 'NewName (00111)'
 
     def test_new_contact_registered_in_index(self, tmp_path, logger):
-        result = wa.sync_folder_names(
+        result = arc.sync_folder_names(
             {'111': 'Alice'}, {}, str(tmp_path), {}, logger
         )
         assert '111' in result
@@ -1165,7 +1171,7 @@ class TestSyncFolderNames:
         # Contact is known by old number '111'; canonical is '222'
         contacts = {'111': 'Alice'}
         number_map = {'111': '222'}
-        result = wa.sync_folder_names(
+        result = arc.sync_folder_names(
             contacts, number_map, str(tmp_path), {}, logger
         )
         # Registered under canonical '222', folder uses canonical number
@@ -1179,7 +1185,7 @@ class TestSyncGroupNames:
         groups_root.mkdir()
         (groups_root / 'Family').mkdir()
         group_index = {'42': {'folder': 'Family', 'subject': 'Family'}}
-        result = wa.sync_group_names(
+        result = arc.sync_group_names(
             {'42': 'Family'}, str(tmp_path), group_index, logger
         )
         assert result['42']['folder'] == 'Family'
@@ -1190,7 +1196,7 @@ class TestSyncGroupNames:
         groups_root.mkdir()
         (groups_root / 'OldName').mkdir()
         group_index = {'42': {'folder': 'OldName', 'subject': 'OldName'}}
-        result = wa.sync_group_names(
+        result = arc.sync_group_names(
             {'42': 'NewName'}, str(tmp_path), group_index, logger
         )
         assert result['42']['folder'] == 'NewName'
@@ -1203,7 +1209,7 @@ class TestSyncGroupNames:
         (groups_root / 'OldName').mkdir()
         (groups_root / 'NewName').mkdir()  # target already exists
         group_index = {'42': {'folder': 'OldName', 'subject': 'OldName'}}
-        result = wa.sync_group_names(
+        result = arc.sync_group_names(
             {'42': 'NewName'}, str(tmp_path), group_index, logger
         )
         # Index is updated even when the on-disk rename is skipped,
@@ -1212,7 +1218,7 @@ class TestSyncGroupNames:
 
     def test_new_group_not_in_index_is_skipped(self, tmp_path, logger):
         # New groups are not yet in group_index; sync_group_names skips them
-        result = wa.sync_group_names(
+        result = arc.sync_group_names(
             {'99': 'Brand New Group'}, str(tmp_path), {}, logger
         )
         assert '99' not in result
@@ -1415,7 +1421,7 @@ class TestProcessRows:
         os.makedirs(out)
         rows = [self._row(chat_subject=None, sender='111', key_from_me=0,
                           file_path='img.jpg')]
-        archive_conn = wa.open_archive_db(out)
+        archive_conn = arc.open_archive_db(out)
         try:
             wa.process_rows(
                 rows, 1, {'111': 'Alice'}, {}, {}, {},
@@ -1518,31 +1524,31 @@ class TestValidateWaRoot:
 
 class TestContactPersistence:
     def test_save_and_load_round_trip(self, tmp_path):
-        conn = wa.open_archive_db(str(tmp_path))
+        conn = arc.open_archive_db(str(tmp_path))
         index = {"391234567890": ("Alice (00391234567890)", "Alice")}
-        wa.save_contacts_to_db(conn, index)
+        arc.save_contacts_to_db(conn, index)
         conn.commit()
-        loaded = wa.load_contacts_from_db(conn)
+        loaded = arc.load_contacts_from_db(conn)
         conn.close()
         assert loaded == index
 
     def test_update_existing_contact(self, tmp_path):
-        conn = wa.open_archive_db(str(tmp_path))
-        wa.save_contacts_to_db(conn, {"111": ("Old Name (00111)", "Old Name")})
-        wa.save_contacts_to_db(conn, {"111": ("New Name (00111)", "New Name")})
+        conn = arc.open_archive_db(str(tmp_path))
+        arc.save_contacts_to_db(conn, {"111": ("Old Name (00111)", "Old Name")})
+        arc.save_contacts_to_db(conn, {"111": ("New Name (00111)", "New Name")})
         conn.commit()
-        loaded = wa.load_contacts_from_db(conn)
+        loaded = arc.load_contacts_from_db(conn)
         conn.close()
         assert loaded["111"] == ("New Name (00111)", "New Name")
 
 
 class TestGroupPersistence:
     def test_save_and_load_round_trip(self, tmp_path):
-        conn = wa.open_archive_db(str(tmp_path))
+        conn = arc.open_archive_db(str(tmp_path))
         index = {"42": {"folder": "Family Chat", "subject": "Family Chat"}}
-        wa.save_groups_to_db(conn, index)
+        arc.save_groups_to_db(conn, index)
         conn.commit()
-        loaded = wa.load_groups_from_db(conn)
+        loaded = arc.load_groups_from_db(conn)
         conn.close()
         assert loaded == index
 

--- a/tests/test_wa_media_archiver.py
+++ b/tests/test_wa_media_archiver.py
@@ -649,6 +649,27 @@ class TestBuildIosQuery:
         rows = conn.execute(ios.build_ios_query(None, None)).fetchall()
         assert rows[0][6] == '447700900456'
 
+    def test_status_media_excluded_from_group_query(self):
+        conn = _make_ios_msgstore()
+        conn.executescript("""
+            INSERT INTO ZWACHATSESSION (Z_PK, ZCONTACTJID, ZGROUPINFO, ZPARTNERNAME) VALUES (1, NULL, 1, 'Group A');
+            INSERT INTO ZWAMEDIAITEM    VALUES (1, 'Media/393384259462@status/6/d/photo.jpg', NULL, NULL);
+            INSERT INTO ZWAGROUPMEMBER  VALUES (1, '447700900123@s.whatsapp.net');
+            INSERT INTO ZWAMESSAGE      VALUES (1, 1000.0, 0, 1, 1, 1, NULL);
+        """)
+        rows = conn.execute(ios.build_ios_query(None, None)).fetchall()
+        assert len(rows) == 0
+
+    def test_status_media_excluded_from_1to1_query(self):
+        conn = _make_ios_msgstore()
+        conn.executescript("""
+            INSERT INTO ZWACHATSESSION (Z_PK, ZCONTACTJID, ZGROUPINFO, ZPARTNERNAME) VALUES (1, '447700900456@s.whatsapp.net', NULL, NULL);
+            INSERT INTO ZWAMEDIAITEM    VALUES (1, 'Media/393384259462@status/6/d/photo.jpg', NULL, NULL);
+            INSERT INTO ZWAMESSAGE      VALUES (1, 1000.0, 0, 1, 1, NULL, NULL);
+        """)
+        rows = conn.execute(ios.build_ios_query(None, None)).fetchall()
+        assert len(rows) == 0
+
 
 # ===========================================================================
 # iOS: build_ios_group_subjects_query structural checks
@@ -666,6 +687,10 @@ class TestBuildIosGroupSubjectsQuery:
     def test_no_date_filter(self):
         query = ios.build_ios_group_subjects_query()
         assert 'ZMESSAGEDATE >=' not in query
+
+    def test_status_media_excluded(self):
+        query = ios.build_ios_group_subjects_query()
+        assert "@status%" in query
 
 
 # ===========================================================================

--- a/tests/test_wa_media_archiver.py
+++ b/tests/test_wa_media_archiver.py
@@ -2080,3 +2080,38 @@ class TestConfigInParseArgs:
              patch("os.getcwd", return_value=str(dir2)):
             with pytest.raises(SystemExit):
                 wa.parse_args()
+
+    def test_config_equals_form(self, tmp_path):
+        cfg = tmp_path / "config.toml"
+        out = self._toml_path(tmp_path)
+        self._write_config(cfg, f'output = "{out}"\nwa_root = "/wa"\n')
+        with patch("sys.argv", ["wa", f"--config={cfg}"]):
+            args = wa.parse_args()
+        assert args.wa_root == "/wa"
+
+    def test_ios_backup_and_wa_root_mutually_exclusive(self, tmp_path):
+        with patch("sys.argv", ["wa", "-o", str(tmp_path),
+                                 "--ios_backup", "/backup", "--wa_root", "/wa"]):
+            with pytest.raises(SystemExit):
+                wa.parse_args()
+
+
+class TestConfigNormalise:
+    def test_since_date_literal_normalised(self, tmp_path):
+        cfg = tmp_path / "config.toml"
+        cfg.write_bytes(b'output = "/tmp"\nsince = 2024-01-01\n')
+        result = wa._load_toml(str(cfg))
+        import datetime
+        assert isinstance(result['since'], datetime.date)
+        # simulate the normalisation that parse_args applies
+        if isinstance(result['since'], datetime.date):
+            result['since'] = result['since'].isoformat()
+        assert result['since'] == "2024-01-01"
+
+    def test_since_wrong_type_exits(self, tmp_path):
+        cfg = tmp_path / "config.toml"
+        out = str(tmp_path).replace('\\', '/')
+        cfg.write_text(f'output = "{out}"\nsince = 123\n', encoding='utf-8')
+        with patch("sys.argv", ["wa", "--config", str(cfg)]):
+            with pytest.raises(SystemExit):
+                wa.parse_args()

--- a/wa_media_archiver.py
+++ b/wa_media_archiver.py
@@ -608,8 +608,7 @@ _EXAMPLE_CONFIG = """\
 # All paths can be absolute or relative to where you run the script.
 # Remove the leading # to activate a setting.
 #
-# Windows tip: backslashes in paths are auto-converted to forward slashes.
-#   You can paste paths as-is; the script handles it and prints a reminder.
+# Windows tip: you can paste Windows paths as-is; backslashes are auto-corrected.
 
 output     = "/path/to/archive"         # required
 # msgstore = "msgstore.db"
@@ -640,10 +639,11 @@ def _load_toml(path: str) -> dict:
         fixed = re.sub(r'"([^"]*)"', lambda m: '"' + m.group(1).replace('\\', '/') + '"', raw.decode('utf-8'))
         try:
             result = tomllib.loads(fixed)
+            with open(path, 'w', encoding='utf-8') as f:
+                f.write(fixed)
             print(
-                f"WARNING: Config file {path} contains backslashes in paths. "
-                "These were automatically converted to forward slashes for this run.\n"
-                "  Update the file to use forward slashes (C:/Users/...) to suppress this warning.",
+                f"NOTE: Backslashes in paths in {path} were automatically converted "
+                "to forward slashes and the file was updated.",
                 file=sys.stderr,
             )
             return result

--- a/wa_media_archiver.py
+++ b/wa_media_archiver.py
@@ -608,8 +608,8 @@ _EXAMPLE_CONFIG = """\
 # All paths can be absolute or relative to where you run the script.
 # Remove the leading # to activate a setting.
 #
-# Windows tip: use forward slashes in paths to avoid TOML parse errors.
-#   output = "C:/Users/Oliver/Desktop/archive"  <- forward slashes work on Windows
+# Windows tip: backslashes in paths are auto-converted to forward slashes.
+#   You can paste paths as-is; the script handles it and prints a reminder.
 
 output     = "/path/to/archive"         # required
 # msgstore = "msgstore.db"
@@ -632,17 +632,24 @@ output     = "/path/to/archive"         # required
 def _load_toml(path: str) -> dict:
     try:
         with open(path, 'rb') as f:
-            return tomllib.load(f)
-    except tomllib.TOMLDecodeError as e:
-        print(f"ERROR: Could not parse config file {path}:\n  {e}", file=sys.stderr)
-        print(
-            "  Tip: Windows paths must use forward slashes or double backslashes:\n"
-            '    output = "C:/Users/Name/Desktop/archive"     ← forward slashes (recommended)\n'
-            '    output = "C:\\\\Users\\\\Name\\\\Desktop\\\\archive"  ← double backslashes\n'
-            "  Single backslashes (\\) are not valid in TOML strings.",
-            file=sys.stderr,
-        )
-        sys.exit(1)
+            raw = f.read()
+        return tomllib.loads(raw.decode('utf-8'))
+    except tomllib.TOMLDecodeError:
+        # Retry with backslashes in quoted string values replaced by forward slashes.
+        # Handles Windows paths like C:\Users\... pasted directly into the config file.
+        fixed = re.sub(r'"([^"]*)"', lambda m: '"' + m.group(1).replace('\\', '/') + '"', raw.decode('utf-8'))
+        try:
+            result = tomllib.loads(fixed)
+            print(
+                f"WARNING: Config file {path} contains backslashes in paths. "
+                "These were automatically converted to forward slashes for this run.\n"
+                "  Update the file to use forward slashes (C:/Users/...) to suppress this warning.",
+                file=sys.stderr,
+            )
+            return result
+        except tomllib.TOMLDecodeError as e:
+            print(f"ERROR: Could not parse config file {path}:\n  {e}", file=sys.stderr)
+            sys.exit(1)
     except OSError as e:
         print(f"ERROR: Could not read config file {path}:\n  {e}", file=sys.stderr)
         sys.exit(1)

--- a/wa_media_archiver.py
+++ b/wa_media_archiver.py
@@ -639,8 +639,8 @@ def _load_toml(path: str) -> dict:
         fixed = re.sub(r'"([^"]*)"', lambda m: '"' + m.group(1).replace('\\', '/') + '"', raw.decode('utf-8'))
         try:
             result = tomllib.loads(fixed)
-            with open(path, 'w', encoding='utf-8') as f:
-                f.write(fixed)
+            with open(path, 'wb') as f:
+                f.write(fixed.encode('utf-8'))
             print(
                 f"NOTE: Backslashes in paths in {path} were automatically converted "
                 "to forward slashes and the file was updated.",

--- a/wa_media_archiver.py
+++ b/wa_media_archiver.py
@@ -44,6 +44,7 @@ import ios_handler
 # Archives WhatsApp media into a structured folder hierarchy using msgstore.db
 # (Android) or ChatStorage.sqlite (iOS). Run on a backup copy of your data.
 # Requires Python 3.11+.
+# https://github.com/auanasgheps/whatsapp-media-archiver
 # ==============================================================================
 
 __version__ = '0.35'

--- a/wa_media_archiver.py
+++ b/wa_media_archiver.py
@@ -1,7 +1,7 @@
 import sys
-if sys.version_info < (3, 10):
+if sys.version_info < (3, 11):
     print(
-        f"ERROR: Python 3.10 or higher is required "
+        f"ERROR: Python 3.11 or higher is required "
         f"(you are running {sys.version.split()[0]}).\n"
         "  Download the latest Python from https://www.python.org/downloads/",
         file=sys.stderr,
@@ -41,10 +41,10 @@ import ios_handler
 # WA Media Archiver
 # Archives WhatsApp media into a structured folder hierarchy using msgstore.db
 # (Android) or ChatStorage.sqlite (iOS). Run on a backup copy of your data.
-# Requires Python 3.10+.
+# Requires Python 3.11+.
 # ==============================================================================
 
-__version__ = '0.34'
+__version__ = '0.35'
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -866,6 +866,61 @@ def run_restore_mode(args, logger):
 
 
 # ---------------------------------------------------------------------------
+# Config file
+# ---------------------------------------------------------------------------
+
+_VALID_CONFIG_KEYS = {
+    'output', 'msgstore', 'e2e_key', 'wa_root', 'contacts', 'log',
+    'mode', 'business', 'timezone', 'since', 'ios_backup', 'ios_password', 'ios_contacts',
+}
+
+_EXAMPLE_CONFIG = """\
+# This is an example config file. Rename it to config.toml to activate it.
+# wa_media_archiver config
+# All paths can be absolute or relative to where you run the script.
+# Remove the leading # to activate a setting.
+
+output     = "/path/to/archive"         # required
+# msgstore = "msgstore.db"
+# e2e_key  = ""
+# wa_root  = ""
+# contacts = ""
+# log      = ""
+# mode     = ""                         # "adb" or "restore"
+# business = false
+# timezone = ""                         # e.g. Europe/Rome
+# since    = ""                         # e.g. 2024-01-01
+
+# iOS
+# ios_backup   = ""
+# ios_password = ""
+# ios_contacts = ""
+"""
+
+
+def _load_toml(path: str) -> dict:
+    import tomllib
+    try:
+        with open(path, 'rb') as f:
+            return tomllib.load(f)
+    except tomllib.TOMLDecodeError as e:
+        print(f"ERROR: Could not parse config file {path}:\n  {e}", file=sys.stderr)
+        sys.exit(1)
+    except OSError as e:
+        print(f"ERROR: Could not read config file {path}:\n  {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+def _generate_config(script_dir: str):
+    dest = os.path.join(script_dir, 'example-config.toml')
+    with open(dest, 'w', encoding='utf-8') as f:
+        f.write(_EXAMPLE_CONFIG)
+    print(f"Written: {dest}")
+    print("Rename it to config.toml and edit the values to activate it.")
+    sys.exit(0)
+
+
+# ---------------------------------------------------------------------------
 # Entry point
 # ---------------------------------------------------------------------------
 
@@ -881,6 +936,14 @@ def parse_args() -> argparse.Namespace:
     )
     parser.add_argument('--version', action='version',
                         version=f'WhatsApp Media Archiver v{__version__}')
+    parser.add_argument('--config',
+                        default=None,
+                        metavar='PATH',
+                        help='Path to a TOML config file. '
+                             'Auto-detected as config.toml in the script folder or cwd if present.')
+    parser.add_argument('--generate-config',
+                        action='store_true',
+                        help='Write example-config.toml to the script folder and exit.')
     parser.add_argument('-msg', '--msgstore',
                         default='msgstore.db',
                         help='Path to msgstore.db[.crypt15] or ChatStorage.sqlite '
@@ -917,7 +980,7 @@ def parse_args() -> argparse.Namespace:
                         help='Target WhatsApp Business instead of the regular WhatsApp app. '
                              'Affects the ADB pull path (Android) and the backup domain (iOS).')
     parser.add_argument('-o', '--output',
-                        required=True,
+                        default=None,
                         help='Output root folder for the archive')
     parser.add_argument('-l', '--log',
                         default=None,
@@ -949,9 +1012,56 @@ def parse_args() -> argparse.Namespace:
                              '(e.g. Europe/Rome, America/New_York, UTC). '
                              'Default: machine local time. '
                              'Windows users: requires pip install tzdata.')
+    # --- Config file detection (peek at sys.argv before argparse runs) ---
+    _script_dir = os.path.dirname(os.path.abspath(__file__))
+    _cwd = os.getcwd()
+
+    if '--generate-config' in sys.argv:
+        _generate_config(_script_dir)
+
+    _config_path = None
+    if '--config' in sys.argv:
+        _idx = sys.argv.index('--config')
+        if _idx + 1 < len(sys.argv):
+            _config_path = sys.argv[_idx + 1]
+    else:
+        _candidates = []
+        for d in dict.fromkeys([_script_dir, _cwd]):
+            p = os.path.join(d, 'config.toml')
+            if os.path.isfile(p):
+                _candidates.append(p)
+
+        if len(_candidates) == 1:
+            answer = input(
+                f"Found config.toml at {_candidates[0]} — use it? [Y/n] "
+            ).strip().lower()
+            if answer in ('', 'y', 'yes'):
+                _config_path = _candidates[0]
+        elif len(_candidates) > 1:
+            print("ERROR: Multiple config files found — specify one with --config:",
+                  file=sys.stderr)
+            for p in _candidates:
+                print(f"  {p}", file=sys.stderr)
+            sys.exit(1)
+
+    if _config_path:
+        _config = _load_toml(_config_path)
+        _unknown = set(_config) - _VALID_CONFIG_KEYS
+        if _unknown:
+            print(
+                f"ERROR: Unknown key(s) in config file {_config_path}:\n"
+                + "\n".join(f"  {k}" for k in sorted(_unknown))
+                + "\n  Check for typos. Valid keys: "
+                + ", ".join(sorted(_VALID_CONFIG_KEYS)),
+                file=sys.stderr,
+            )
+            sys.exit(1)
+        parser.set_defaults(**_config)
+
     args = parser.parse_args()
 
-    if args.ios_backup and args.wa_root:
+    if not args.output:
+        parser.error("the following arguments are required: -o/--output")
         parser.error("--ios_backup and --wa_root are mutually exclusive.")
     if args.ios_backup and args.mode == 'adb':
         parser.error("--ios_backup and --mode adb are mutually exclusive.")

--- a/wa_media_archiver.py
+++ b/wa_media_archiver.py
@@ -24,7 +24,7 @@ import tempfile
 import zlib
 from datetime import datetime
 
-_REQUIRED_MODULES = ['adb_extractor', 'android_handler', 'backup_reader', 'ios_handler']
+_REQUIRED_MODULES = ['adb_extractor', 'android_handler', 'archive_db', 'backup_reader', 'ios_handler']
 _script_dir = os.path.dirname(os.path.abspath(__file__))
 _missing = [m for m in _REQUIRED_MODULES if not os.path.isfile(os.path.join(_script_dir, m + '.py'))]
 if _missing:
@@ -34,6 +34,7 @@ if _missing:
 
 import adb_extractor
 import android_handler
+import archive_db
 import backup_reader
 import ios_handler
 
@@ -257,281 +258,6 @@ def write_duplicate_report(report_path: str, conn: sqlite3.Connection,
 
 
 # ---------------------------------------------------------------------------
-# Archive DB
-# ---------------------------------------------------------------------------
-
-def open_archive_db(output_root: str) -> sqlite3.Connection:
-    """
-    Open (or create) the archive state database.
-    Returns an open connection with foreign keys enabled.
-    """
-    db_path = os.path.join(output_root, '.wa_media_archiver.db')
-    conn = sqlite3.connect(db_path)
-    conn.execute("PRAGMA journal_mode = WAL")
-    conn.execute("PRAGMA auto_vacuum = INCREMENTAL")
-    conn.execute("PRAGMA foreign_keys = ON")
-    conn.executescript("""
-        CREATE TABLE IF NOT EXISTS contacts (
-            number        TEXT PRIMARY KEY,
-            folder        TEXT NOT NULL,
-            display_name  TEXT NOT NULL DEFAULT ''
-        );
-        CREATE TABLE IF NOT EXISTS groups (
-            chat_row_id  TEXT PRIMARY KEY,
-            folder       TEXT NOT NULL,
-            subject      TEXT NOT NULL DEFAULT ''
-        );
-        CREATE TABLE IF NOT EXISTS files (
-            original_path  TEXT PRIMARY KEY,
-            md5            BLOB NOT NULL
-        );
-        CREATE TABLE IF NOT EXISTS archive_copies (
-            original_path  TEXT NOT NULL REFERENCES files(original_path),
-            archive_path   TEXT NOT NULL,
-            PRIMARY KEY (original_path, archive_path)
-        );
-        CREATE INDEX IF NOT EXISTS idx_files_md5 ON files(md5);
-    """)
-    return conn
-
-
-def load_contacts_from_db(conn: sqlite3.Connection) -> dict:
-    """Load contact folder index: number -> (folder, display_name)."""
-    return {row[0]: (row[1], row[2])
-            for row in conn.execute("SELECT number, folder, display_name FROM contacts")}
-
-
-def save_contacts_to_db(conn: sqlite3.Connection, index: dict):
-    """Persist contact folder index to DB."""
-    conn.executemany(
-        "INSERT OR REPLACE INTO contacts (number, folder, display_name) VALUES (?, ?, ?)",
-        ((number, folder, display_name) for number, (folder, display_name) in index.items())
-    )
-
-
-def load_groups_from_db(conn: sqlite3.Connection) -> dict:
-    """Load group folder index: str(chat_row_id) -> {folder, subject}."""
-    return {
-        row[0]: {'folder': row[1], 'subject': row[2]}
-        for row in conn.execute(
-            "SELECT chat_row_id, folder, subject FROM groups"
-        )
-    }
-
-
-def save_groups_to_db(conn: sqlite3.Connection, index: dict):
-    """Persist group folder index to DB."""
-    conn.executemany(
-        "INSERT OR REPLACE INTO groups (chat_row_id, folder, subject) VALUES (?, ?, ?)",
-        ((key, val['folder'], val['subject']) for key, val in index.items())
-    )
-
-
-def record_file_archived(cursor: sqlite3.Cursor,
-                         original_path: str, md5: bytes, archive_path: str):
-    """Record that original_path was archived to archive_path with given md5."""
-    cursor.execute(
-        "INSERT INTO files (original_path, md5) VALUES (?, ?) "
-        "ON CONFLICT(original_path) DO UPDATE SET md5 = excluded.md5",
-        (original_path, md5)
-    )
-    cursor.execute(
-        "INSERT OR IGNORE INTO archive_copies (original_path, archive_path) VALUES (?, ?)",
-        (original_path, archive_path)
-    )
-
-
-def check_db_health(conn: sqlite3.Connection, logger: logging.Logger):
-    """Run quick integrity and foreign key checks; abort on failure."""
-    results = conn.execute("PRAGMA quick_check").fetchall()
-    if results != [('ok',)]:
-        for row in results:
-            logger.error(f"Database integrity issue: {row[0]}")
-        raise SystemExit(1)
-
-    issues = conn.execute("PRAGMA foreign_key_check").fetchall()
-    if issues:
-        for table, rowid, parent, fkid in issues:
-            logger.error(
-                f"Foreign key violation in '{table}': rowid={rowid}, "
-                f"references '{parent}' (fk #{fkid})"
-            )
-        raise SystemExit(1)
-
-    logger.debug("Database health check passed.")
-
-
-def _unique_group_name(desired: str, existing: set) -> str:
-    """Return desired if unused, else append ' (2)', ' (3)', ... until unique."""
-    if desired not in existing:
-        return desired
-    counter = 2
-    while True:
-        candidate = f"{desired} ({counter})"
-        if candidate not in existing:
-            return candidate
-        counter += 1
-
-
-def sync_group_names(group_subjects: dict, output_root: str,
-                     group_index: dict, logger: logging.Logger,
-                     conn: sqlite3.Connection | None = None,
-                     dry_run: bool = False) -> dict:
-    """
-    Detect group renames since the last run and rename folders on disk.
-    group_subjects: {str(chat_row_id): current chat_subject} built from query rows.
-    Mirrors sync_folder_names behaviour for contacts.
-    """
-    groups_root = os.path.join(output_root, 'Groups')
-    updated = dict(group_index)
-
-    for key, current_subject in group_subjects.items():
-        if key not in updated:
-            continue  # new group — assigned later in resolve_group_folder
-
-        entry = updated[key]
-        old_folder = entry['folder']
-        old_subject = entry.get('subject', '')
-
-        if current_subject == old_subject:
-            continue
-
-        desired = sanitize_filename(current_subject) if current_subject \
-            else f"Unknown Group ({key})"
-        existing = {v['folder'] for k2, v in updated.items() if k2 != key}
-        new_folder = _unique_group_name(desired, existing)
-
-        old_path = os.path.join(groups_root, old_folder)
-        new_path = os.path.join(groups_root, new_folder)
-
-        if os.path.exists(old_path):
-            if os.path.exists(new_path):
-                logger.warning(
-                    f"RENAME skipped — target already exists: "
-                    f"{old_folder} -> {new_folder}"
-                )
-            else:
-                if dry_run:
-                    logger.info(f"[DRY RUN] Would rename group folder: {old_folder} -> {new_folder}")
-                    continue
-                else:
-                    os.rename(old_path, new_path)
-                    logger.info(f"RENAMED group folder: {old_folder} -> {new_folder}")
-                    if conn is not None:
-                        old_prefix = f"Groups/{old_folder}/"
-                        new_prefix = f"Groups/{new_folder}/"
-                        conn.execute(
-                            "UPDATE archive_copies "
-                            "SET archive_path = ? || SUBSTR(archive_path, ?) "
-                            "WHERE archive_path LIKE ? ESCAPE '\\'",
-                            (new_prefix, len(old_prefix) + 1,
-                             f"{escape_like(old_prefix)}%")
-                        )
-        else:
-            logger.debug(
-                f"Group folder name changed but no folder on disk yet: "
-                f"{old_folder} -> {new_folder}"
-            )
-
-        updated[key] = {'folder': new_folder, 'subject': current_subject}
-
-    return updated
-
-
-def resolve_group_folder(chat_row_id: int, chat_subject: str | None,
-                         group_index: dict) -> str:
-    """
-    Return the stable folder name for a group.
-    If the group is new, assign a unique name — disambiguating with a counter
-    suffix if another group already uses the same subject.
-    Mutates group_index in-place.
-    """
-    key = str(chat_row_id)
-    if key in group_index:
-        return group_index[key]['folder']
-
-    desired = sanitize_filename(chat_subject) if chat_subject \
-        else f"Unknown Group ({chat_row_id})"
-    existing = {v['folder'] for v in group_index.values()}
-    folder = _unique_group_name(desired, existing)
-    group_index[key] = {'folder': folder, 'subject': chat_subject or ''}
-    return folder
-
-
-def sync_folder_names(contacts: dict, number_map: dict, output_root: str,
-                      folder_index: dict, logger: logging.Logger,
-                      conn: sqlite3.Connection | None = None,
-                      dry_run: bool = False) -> dict:
-    """
-    Compare current contact names against the persisted folder index.
-    If a contact name has changed since the last run, rename the folder
-    on disk so existing files are not re-copied and the archive stays
-    consolidated.
-
-    Returns an updated copy of the index.
-    """
-    contacts_root = os.path.join(output_root, 'Contacts')
-    updated_index = dict(folder_index)
-
-    for number, display_name in contacts.items():
-        # Resolve to canonical number in case of number change
-        canonical = number_map.get(number, number)
-        new_folder = build_contact_folder_name(display_name, canonical)
-        entry = folder_index.get(canonical)
-        old_folder = entry[0] if entry is not None else None
-
-        if old_folder is None:
-            # First time we have seen this contact — just register it
-            updated_index[canonical] = (new_folder, display_name)
-            continue
-
-        if old_folder == new_folder:
-            # Name unchanged — update display_name in case it changed subtly
-            updated_index[canonical] = (new_folder, display_name)
-            continue
-
-        # Name has changed — rename folder on disk if it exists
-        old_path = os.path.join(contacts_root, old_folder)
-        new_path = os.path.join(contacts_root, new_folder)
-
-        if os.path.exists(old_path):
-            if os.path.exists(new_path):
-                # Edge case: new folder name already exists (another contact?)
-                logger.warning(
-                    f"RENAME skipped — target already exists: "
-                    f"{old_folder} -> {new_folder}"
-                )
-            else:
-                if dry_run:
-                    logger.info(f"[DRY RUN] Would rename contact folder: {old_folder} -> {new_folder}")
-                    continue
-                else:
-                    os.rename(old_path, new_path)
-                    logger.info(
-                        f"RENAMED contact folder: {old_folder} -> {new_folder}"
-                    )
-                    if conn is not None:
-                        old_prefix = f"Contacts/{old_folder}/"
-                        new_prefix = f"Contacts/{new_folder}/"
-                        conn.execute(
-                            "UPDATE archive_copies "
-                            "SET archive_path = ? || SUBSTR(archive_path, ?) "
-                            "WHERE archive_path LIKE ? ESCAPE '\\'",
-                            (new_prefix, len(old_prefix) + 1,
-                             f"{escape_like(old_prefix)}%")
-                        )
-        else:
-            logger.debug(
-                f"Folder name changed but no folder on disk yet: "
-                f"{old_folder} -> {new_folder}"
-            )
-
-        updated_index[canonical] = (new_folder, display_name)
-
-    return updated_index
-
-
-# ---------------------------------------------------------------------------
 # Core processing
 # ---------------------------------------------------------------------------
 
@@ -566,7 +292,7 @@ def _route_group(chat_row_id, chat_subject, sender, key_from_me,
                  contacts, number_map, filename, year, output_root,
                  group_index) -> tuple[str, str]:
     """Resolve dest_dir and dest_filename for a group chat message. Mutates group_index."""
-    group_name = resolve_group_folder(chat_row_id, chat_subject, group_index)
+    group_name = archive_db.resolve_group_folder(chat_row_id, chat_subject, group_index)
     canonical = number_map.get(sender, sender)
     sender_display = 'Me' if (key_from_me == 1 or not sender) \
         else contacts.get(canonical, format_phone(canonical))
@@ -611,7 +337,7 @@ def _copy_or_skip(src, dest_path, dest_dir, file_path, timestamp,
         if resolved is None:
             if cursor is not None:
                 rel = os.path.relpath(dest_path, output_root).replace(os.sep, '/')
-                record_file_archived(cursor, file_path, src_hash, rel)
+                archive_db.record_file_archived(cursor, file_path, src_hash, rel)
             return 0, 1, 0
     else:
         src_hash = None
@@ -632,7 +358,7 @@ def _copy_or_skip(src, dest_path, dest_dir, file_path, timestamp,
     logger.debug(f"COPIED: {src} -> {resolved}")
     if cursor is not None:
         rel = os.path.relpath(resolved, output_root).replace(os.sep, '/')
-        record_file_archived(cursor, file_path, src_hash, rel)
+        archive_db.record_file_archived(cursor, file_path, src_hash, rel)
     return 1, 0, 0
 
 
@@ -722,9 +448,9 @@ def run_restore_mode(args, logger):
     Queries .wa_media_archiver.db to determine original file paths and their archive copies.
     The reconstructed tree is written to <output>/Media/.
     """
-    conn = open_archive_db(args.output)
+    conn = archive_db.open_archive_db(args.output)
     try:
-        check_db_health(conn, logger)
+        archive_db.check_db_health(conn, logger)
         file_count = conn.execute(
             "SELECT COUNT(DISTINCT original_path) FROM archive_copies"
         ).fetchone()[0]
@@ -1324,22 +1050,22 @@ def run_forward_mode(args: argparse.Namespace, logger: logging.Logger):
         ).fetchone()[0]
         logger.info(f"Query returned {total_rows} rows.")
 
-        archive_conn = open_archive_db(args.output)
+        archive_conn = archive_db.open_archive_db(args.output)
         try:
-            check_db_health(archive_conn, logger)
-            folder_index = load_contacts_from_db(archive_conn)
+            archive_db.check_db_health(archive_conn, logger)
+            folder_index = archive_db.load_contacts_from_db(archive_conn)
             logger.info(f"Contact index loaded: {len(folder_index)} known contact(s).")
 
-            group_index = load_groups_from_db(archive_conn)
+            group_index = archive_db.load_groups_from_db(archive_conn)
             logger.info(f"Group index loaded: {len(group_index)} known group(s).")
 
-            folder_index = sync_folder_names(
+            folder_index = archive_db.sync_folder_names(
                 contacts, number_map, args.output, folder_index, logger,
                 conn=archive_conn if not args.dry_run else None,
                 dry_run=args.dry_run,
             )
 
-            group_index = sync_group_names(
+            group_index = archive_db.sync_group_names(
                 group_subjects, args.output, group_index, logger,
                 conn=archive_conn if not args.dry_run else None,
                 dry_run=args.dry_run,
@@ -1358,8 +1084,8 @@ def run_forward_mode(args: argparse.Namespace, logger: logging.Logger):
 
             if not args.dry_run:
                 archive_conn.commit()
-                save_contacts_to_db(archive_conn, updated_index)
-                save_groups_to_db(archive_conn, updated_group_index)
+                archive_db.save_contacts_to_db(archive_conn, updated_index)
+                archive_db.save_groups_to_db(archive_conn, updated_group_index)
                 archive_conn.execute("ANALYZE")
                 archive_conn.commit()
                 logger.info(f"Archive DB saved: {len(updated_index)} contact(s), "

--- a/wa_media_archiver.py
+++ b/wa_media_archiver.py
@@ -21,8 +21,9 @@ import sqlite3
 import subprocess
 import sys
 import tempfile
+import tomllib
 import zlib
-from datetime import datetime
+from datetime import date, datetime
 
 _REQUIRED_MODULES = ['adb_extractor', 'android_handler', 'archive_db', 'backup_reader', 'ios_handler']
 _script_dir = os.path.dirname(os.path.abspath(__file__))
@@ -625,7 +626,6 @@ output     = "/path/to/archive"         # required
 
 
 def _load_toml(path: str) -> dict:
-    import tomllib
     try:
         with open(path, 'rb') as f:
             return tomllib.load(f)
@@ -746,11 +746,14 @@ def parse_args() -> argparse.Namespace:
         _generate_config(_script_dir)
 
     _config_path = None
-    if '--config' in sys.argv:
-        _idx = sys.argv.index('--config')
-        if _idx + 1 < len(sys.argv):
-            _config_path = sys.argv[_idx + 1]
-    else:
+    for _i, _arg in enumerate(sys.argv[1:], 1):
+        if _arg.startswith('--config='):
+            _config_path = _arg[len('--config='):]
+            break
+        if _arg == '--config' and _i < len(sys.argv) - 1:
+            _config_path = sys.argv[_i + 1]
+            break
+    if _config_path is None:
         _candidates = []
         for d in dict.fromkeys([_script_dir, _cwd]):
             p = os.path.join(d, 'config.toml')
@@ -782,12 +785,24 @@ def parse_args() -> argparse.Namespace:
                 file=sys.stderr,
             )
             sys.exit(1)
+        if 'since' in _config:
+            _since_val = _config['since']
+            if isinstance(_since_val, date):
+                _config['since'] = _since_val.isoformat()
+            elif not isinstance(_since_val, str):
+                print(
+                    f"ERROR: 'since' in config must be a quoted date string "
+                    f"(e.g. since = \"2024-01-01\"), got {type(_since_val).__name__}",
+                    file=sys.stderr,
+                )
+                sys.exit(1)
         parser.set_defaults(**_config)
 
     args = parser.parse_args()
 
     if not args.output:
         parser.error("the following arguments are required: -o/--output")
+    if args.ios_backup and args.wa_root:
         parser.error("--ios_backup and --wa_root are mutually exclusive.")
     if args.ios_backup and args.mode == 'adb':
         parser.error("--ios_backup and --mode adb are mutually exclusive.")

--- a/wa_media_archiver.py
+++ b/wa_media_archiver.py
@@ -607,6 +607,9 @@ _EXAMPLE_CONFIG = """\
 # wa_media_archiver config
 # All paths can be absolute or relative to where you run the script.
 # Remove the leading # to activate a setting.
+#
+# Windows tip: use forward slashes in paths to avoid TOML parse errors.
+#   output = "C:/Users/Oliver/Desktop/archive"  <- forward slashes work on Windows
 
 output     = "/path/to/archive"         # required
 # msgstore = "msgstore.db"
@@ -632,6 +635,13 @@ def _load_toml(path: str) -> dict:
             return tomllib.load(f)
     except tomllib.TOMLDecodeError as e:
         print(f"ERROR: Could not parse config file {path}:\n  {e}", file=sys.stderr)
+        print(
+            "  Tip: Windows paths must use forward slashes or double backslashes:\n"
+            '    output = "C:/Users/Name/Desktop/archive"     ← forward slashes (recommended)\n'
+            '    output = "C:\\\\Users\\\\Name\\\\Desktop\\\\archive"  ← double backslashes\n'
+            "  Single backslashes (\\) are not valid in TOML strings.",
+            file=sys.stderr,
+        )
         sys.exit(1)
     except OSError as e:
         print(f"ERROR: Could not read config file {path}:\n  {e}", file=sys.stderr)


### PR DESCRIPTION
### Added

- **Config file support (`--config`, `--generate-config`)**: users can now save persistent settings in a `config.toml` file instead of retyping long commands every run.
  - `--generate-config` writes an annotated `example-config.toml` next to the script and exits. Rename it to `config.toml` to activate it.
  - `--config PATH` loads a specific file; if omitted, the script auto-detects `config.toml` in the script folder or the current working directory. One file found → confirmation prompt. Two files found → error (use `--config` to disambiguate).
  - All persistent arguments are supported in the config file, including `--since`. `--dry-run` and `--limit` are intentionally excluded (one-off per run).
  - CLI arguments always win over config file values.
  - Unknown keys in the config file exit with a clear error listing valid keys.
  - Uses `tomllib` (stdlib since Python 3.11) — zero extra dependency.
- **Bumped minimum Python version to 3.11** (from 3.10) — required by `tomllib`. The version gate at startup and all documentation updated accordingly.

### Changed

- **Extracted `archive_db.py`**: all archive database logic moved from `wa_media_archiver.py` into a new companion module

### Fixed

- **Windows paths with backslashes in `config.toml` are now auto-corrected**: instead of exiting with a cryptic TOML parse error, the script converts backslashes in quoted string values to forward slashes, writes the corrected file back to disk, and continues the run. Genuinely invalid TOML still exits with an error.
- **TOML unquoted date literal for `since` causes `TypeError`**: `since = 2024-01-01` (no quotes) is valid TOML and parses as `datetime.date`. The value is now silently normalised to an ISO string before `set_defaults`. Any other unexpected type (e.g. integer) exits with a clear error message.
- **WhatsApp Status media incorrectly archived as contact media (iOS)**: media files with `@status` in their `ZMEDIALOCALPATH` were being matched by the iOS query and routed into the sender's contact folder as received media. Status updates are not conversation media. Excluded.
- **macOS Full Disk Access error on iOS backup**: reading files inside `~/Library/Application Support/MobileSync/Backup/` fails with `PermissionError` on macOS unless the Terminal process has Full Disk Access.
- - **`--ios_backup` + `--wa_root` mutual exclusion not enforced**
- **`--config=path` (equals-sign form) silently ignored**

### Documentation

- `docs/running-the-script.md`: added `--config` and `--generate-config` to the command reference and added a new **Config File** section explaining the format, auto-detection rules, and precedence. Windows backslash auto-correction noted.
- `docs/prerequisites.md`: improve Windows instructions
- `readme.md`: add icon